### PR TITLE
Keep releases lean

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+.gitattributes export-ignore
+.gitignore export-ignore
+LICENSE export-ignore
+phpunit.xml.dist export-ignore
+README.md export-ignore
+tests/ export-ignore


### PR DESCRIPTION
Keep unnecessary files out of releases/dists. If you want to ship the license file remove it's export-ignore.