### PR TITLE
Don't export Travis CI configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
+.travis.yml export-ignore
 LICENSE export-ignore
 phpunit.xml.dist export-ignore
 README.md export-ignore


### PR DESCRIPTION
We don't need the Travis CI configuration in releases. 

Lean releases rule of thumb:
> When adding new dotfiles or other non-release related files they have to be `export-ignored`.