### PR TITLE
Optimise Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+git:
+  depth: 1
+
 php:
   - 5.6
   - 7.0
@@ -8,8 +11,12 @@ php:
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
-  - composer install -n --dev --prefer-source
+  - composer install -n
 
 script: vendor/bin/phpunit
 


### PR DESCRIPTION
Speed up the Travis CI builds. 

When moving in the direction of gathering code coverage e.g. via [Code Climate](https://codeclimate.com/) Xdebug has to be re-enabled. 