### PR TITLE
Extend git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
+# User specific & automatically generated files #
+#################################################
 composer.lock
+/phpunit.xml
+/phpcs.xml
 vendor
+
+# IDE and editor specific files #
+#################################
+/nbproject
 .idea
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
One could argue that these should be moved to one's global system git ignore file, but this way it works when somebody has no such file setup.