### PR TITLE
Enable PDS compliance

### DIFF
--- a/bin/phpmnd
+++ b/bin/phpmnd
@@ -15,7 +15,10 @@ if (version_compare('5.6.0', PHP_VERSION, '>')) {
 }
 
 $loaded = false;
-foreach ([__DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php'] as $file) {
+$autoloads = [
+    __DIR__ . '/../vendor/autoload.php',
+];
+foreach ($autoloads as $file) {
    if (file_exists($file)) {
       require_once $file;
       $loaded = true;

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
       "Povils\\PHPMND\\Tests\\": "tests/"
     }
   },
-  "bin": ["phpmnd"],
+  "bin": ["bin/phpmnd"],
   "scripts": {
     "test": "phpunit",
     "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",


### PR DESCRIPTION
The CLI binary has been moved to `bin` to achieve [PDS](http://php-pds.com) compliance.