### PR TITLE
Add support for PHPUnit 6+.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,21 +12,16 @@
   "support": {
     "issues": "https://github.com/povils/phpmnd/issues"
   },
-  "config": {
-    "platform": {
-      "php": "5.6.0"
-    }
-  },
   "require": {
     "php": "^5.6|^7.0",
     "symfony/console": "^2.4 || ^3.0",
     "symfony/finder": "^2.2 || ^3.0",
     "nikic/php-parser": "^3.0",
     "jakub-onderka/php-console-highlighter": "^0.3.2",
-    "phpunit/php-timer": "^1.0.6"
+    "phpunit/php-timer": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.5 || ^5.0"
+    "phpunit/phpunit": "^5.7 || ^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -10,13 +10,14 @@ use Povils\PHPMND\Extension\AssignExtension;
 use Povils\PHPMND\Extension\DefaultParameterExtension;
 use Povils\PHPMND\Extension\OperationExtension;
 use Povils\PHPMND\Extension\PropertyExtension;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class DetectorTest
  *
  * @package Povils\PHPMND\Tests
  */
-class DetectorTest extends \PHPUnit_Framework_TestCase
+class DetectorTest extends TestCase
 {
     public function testDetectDefault()
     {

--- a/tests/FileReportTest.php
+++ b/tests/FileReportTest.php
@@ -4,13 +4,14 @@ namespace Povils\PHPMND\Tests;
 
 use Povils\PHPMND\FileReport;
 use Symfony\Component\Finder\SplFileInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FileReportTest
  *
  * @package Povils\PHPMND\Tests
  */
-class FileReportTest extends \PHPUnit_Framework_TestCase
+class FileReportTest extends TestCase
 {
     public function testFileReport()
     {


### PR DESCRIPTION
* This removes the fixed "platform" config in composer which was set to PHP 5.6.0.
* This sets the minimum PHPUnit version to 5.7 (which has forward compatibility).
* Using `--prefer-lowest` flag with Composer may still install the usual PHPUnit-1.0.0-alpha package which may break.