### PR TITLE
Update namespace to a more neutral PHPMND

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
   },
   "autoload": {
     "psr-4": {
-      "Povils\\PHPMND\\": "src/"
+      "PHPMND\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Povils\\PHPMND\\Tests\\": "tests/"
+      "PHPMND\\Tests\\": "tests/"
     }
   },
   "bin": ["phpmnd"],

--- a/phpmnd
+++ b/phpmnd
@@ -32,5 +32,5 @@ if (false === $loaded) {
 }
 ini_set('xdebug.max_nesting_level', 10000);
 
-$application = new Povils\PHPMND\Console\Application;
+$application = new PHPMND\Console\Application;
 $application->run();

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Console;
+namespace PHPMND\Console;
 
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Class Application
  *
- * @package Povils\PHPMND\Console
+ * @package PHPMND\Console
  */
 class Application extends BaseApplication
 {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Povils\PHPMND\Console;
+namespace PHPMND\Console;
 
-use Povils\PHPMND\Detector;
-use Povils\PHPMND\ExtensionFactory;
-use Povils\PHPMND\PHPFinder;
-use Povils\PHPMND\Printer;
+use PHPMND\Detector;
+use PHPMND\ExtensionFactory;
+use PHPMND\PHPFinder;
+use PHPMND\Printer;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Class Command
  *
- * @package Povils\PHPMND\Console
+ * @package PHPMND\Console
  */
 class Command extends BaseCommand
 {

--- a/src/Console/Option.php
+++ b/src/Console/Option.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Povils\PHPMND\Console;
+namespace PHPMND\Console;
 
-use Povils\PHPMND\Extension\DefaultExtension;
-use Povils\PHPMND\Extension\Extension;
+use PHPMND\Extension\DefaultExtension;
+use PHPMND\Extension\Extension;
 
 /**
- * @package Povils\PHPMND\Console
+ * @package PHPMND\Console
  */
 class Option
 {

--- a/src/Detector.php
+++ b/src/Detector.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Povils\PHPMND;
+namespace PHPMND;
 
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
-use Povils\PHPMND\Console\Option;
-use Povils\PHPMND\Visitor\DetectorVisitor;
-use Povils\PHPMND\Visitor\ParentConnectorVisitor;
+use PHPMND\Console\Option;
+use PHPMND\Visitor\DetectorVisitor;
+use PHPMND\Visitor\ParentConnectorVisitor;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Class Detector
  *
- * @package Povils\PHPMND
+ * @package PHPMND
  */
 class Detector
 {

--- a/src/Extension/ArgumentExtension.php
+++ b/src/Extension/ArgumentExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Extension;
+namespace PHPMND\Extension;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
@@ -10,7 +10,7 @@ use PhpParser\Node\Name;
 /**
  * Class ArgumentExtension
  *
- * @package Povils\PHPMND\Extension
+ * @package PHPMND\Extension
  */
 class ArgumentExtension implements FunctionAwareExtension
 {

--- a/src/Extension/ArrayExtension.php
+++ b/src/Extension/ArrayExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Extension;
+namespace PHPMND\Extension;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayItem;
@@ -8,7 +8,7 @@ use PhpParser\Node\Expr\ArrayItem;
 /**
  * Class ArrayExtension
  *
- * @package Povils\PHPMND\Extension
+ * @package PHPMND\Extension
  */
 class ArrayExtension implements Extension
 {

--- a/src/Extension/AssignExtension.php
+++ b/src/Extension/AssignExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Extension;
+namespace PHPMND\Extension;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
@@ -8,7 +8,7 @@ use PhpParser\Node\Expr\Assign;
 /**
  * Class AssignExtension
  *
- * @package Povils\PHPMND\Extension
+ * @package PHPMND\Extension
  */
 class AssignExtension implements Extension
 {

--- a/src/Extension/DefaultExtension.php
+++ b/src/Extension/DefaultExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Extension;
+namespace PHPMND\Extension;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp;

--- a/src/Extension/DefaultParameterExtension.php
+++ b/src/Extension/DefaultParameterExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Extension;
+namespace PHPMND\Extension;
 
 use PhpParser\Node;
 use PhpParser\Node\Param;
@@ -8,7 +8,7 @@ use PhpParser\Node\Param;
 /**
  * Class DefaultParameterExtension
  *
- * @package Povils\PHPMND\Extension
+ * @package PHPMND\Extension
  */
 class DefaultParameterExtension implements Extension
 {

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Extension;
+namespace PHPMND\Extension;
 
 use PhpParser\Node;
 

--- a/src/Extension/FunctionAwareExtension.php
+++ b/src/Extension/FunctionAwareExtension.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Povils\PHPMND\Extension;
+namespace PHPMND\Extension;
 
 use PhpParser\Node;
 
 /**
- * @package Povils\PHPMND\Extension
+ * @package PHPMND\Extension
  */
 interface FunctionAwareExtension extends Extension
 {

--- a/src/Extension/OperationExtension.php
+++ b/src/Extension/OperationExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Extension;
+namespace PHPMND\Extension;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Div;
@@ -15,7 +15,7 @@ use PhpParser\Node\Expr\BinaryOp\ShiftRight;
 /**
  * Class OperationExtension
  *
- * @package Povils\PHPMND\Extension
+ * @package PHPMND\Extension
  */
 class OperationExtension implements Extension
 {

--- a/src/Extension/PropertyExtension.php
+++ b/src/Extension/PropertyExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Extension;
+namespace PHPMND\Extension;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\PropertyProperty;
@@ -8,7 +8,7 @@ use PhpParser\Node\Stmt\PropertyProperty;
 /**
  * Class PropertyExtension
  *
- * @package Povils\PHPMND\Extension
+ * @package PHPMND\Extension
  */
 class PropertyExtension implements Extension
 {

--- a/src/ExtensionFactory.php
+++ b/src/ExtensionFactory.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Povils\PHPMND;
+namespace PHPMND;
 
-use Povils\PHPMND\Extension\Extension;
+use PHPMND\Extension\Extension;
 
 /**
  * Class ExtensionFactory
  *
- * @package Povils\PHPMND
+ * @package PHPMND
  */
 class ExtensionFactory
 {
@@ -19,7 +19,7 @@ class ExtensionFactory
      */
     public static function create($extensionName)
     {
-        $extensionClassName = 'Povils\PHPMND\Extension\\' . self::pascalCase($extensionName) . 'Extension';
+        $extensionClassName = 'PHPMND\Extension\\' . self::pascalCase($extensionName) . 'Extension';
         if (false === class_exists($extensionClassName)) {
             throw new \Exception(sprintf('Extension "%s" does not exist', $extensionName));
         }

--- a/src/FileReport.php
+++ b/src/FileReport.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Povils\PHPMND;
+namespace PHPMND;
 
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
- * @package Povils\PHPMND
+ * @package PHPMND
  */
 class FileReport
 {

--- a/src/PHPFinder.php
+++ b/src/PHPFinder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND;
+namespace PHPMND;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Finder\Finder;
@@ -8,7 +8,7 @@ use Symfony\Component\Finder\Finder;
 /**
  * Class Finder
  *
- * @package Povils\PHPMND
+ * @package PHPMND
  */
 class PHPFinder extends Finder
 {

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND;
+namespace PHPMND;
 
 use JakubOnderka\PhpConsoleColor\ConsoleColor;
 use JakubOnderka\PhpConsoleHighlighter\Highlighter;
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Class Printer
  *
- * @package Povils\PHPMND
+ * @package PHPMND
  */
 class Printer
 {

--- a/src/Visitor/DetectorVisitor.php
+++ b/src/Visitor/DetectorVisitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Visitor;
+namespace PHPMND\Visitor;
 
 use PhpParser\Node;
 use PhpParser\Node\Const_;
@@ -9,15 +9,15 @@ use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use Povils\PHPMND\Console\Option;
-use Povils\PHPMND\Extension\Extension;
-use Povils\PHPMND\Extension\FunctionAwareExtension;
-use Povils\PHPMND\FileReport;
+use PHPMND\Console\Option;
+use PHPMND\Extension\Extension;
+use PHPMND\Extension\FunctionAwareExtension;
+use PHPMND\FileReport;
 
 /**
  * Class DetectorVisitor
  *
- * @package Povils\PHPMND
+ * @package PHPMND
  */
 class DetectorVisitor extends NodeVisitorAbstract
 {

--- a/src/Visitor/ParentConnectorVisitor.php
+++ b/src/Visitor/ParentConnectorVisitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Povils\PHPMND\Visitor;
+namespace PHPMND\Visitor;
 
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;

--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace Povils\PHPMND\Tests;
+namespace PHPMND\Tests;
 
-use Povils\PHPMND\Console\Option;
-use Povils\PHPMND\Detector;
-use Povils\PHPMND\Extension\ArgumentExtension;
-use Povils\PHPMND\Extension\ArrayExtension;
-use Povils\PHPMND\Extension\AssignExtension;
-use Povils\PHPMND\Extension\DefaultParameterExtension;
-use Povils\PHPMND\Extension\OperationExtension;
-use Povils\PHPMND\Extension\PropertyExtension;
+use PHPMND\Console\Option;
+use PHPMND\Detector;
+use PHPMND\Extension\ArgumentExtension;
+use PHPMND\Extension\ArrayExtension;
+use PHPMND\Extension\AssignExtension;
+use PHPMND\Extension\DefaultParameterExtension;
+use PHPMND\Extension\OperationExtension;
+use PHPMND\Extension\PropertyExtension;
 
 /**
  * Class DetectorTest
  *
- * @package Povils\PHPMND\Tests
+ * @package PHPMND\Tests
  */
 class DetectorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/FileReportTest.php
+++ b/tests/FileReportTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Povils\PHPMND\Tests;
+namespace PHPMND\Tests;
 
-use Povils\PHPMND\FileReport;
+use PHPMND\FileReport;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Class FileReportTest
  *
- * @package Povils\PHPMND\Tests
+ * @package PHPMND\Tests
  */
 class FileReportTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
On a tangent to #23 - PHPMND seems to be a better root namespace for an independent project with no other obvious relationships.

This is literally from running: `grep -rl 'Povils\\PHPMND' . | xargs sed -i 's/Povils\\PHPMND/PHPMND/g'`