### PR TITLE
Fix coding standard violations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
   "bin": ["bin/phpmnd"],
   "scripts": {
     "test": "phpunit",
-    "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
-    "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
+    "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/files",
+    "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/files"
   },
   "extra": {
     "branch-alias": {

--- a/src/ExtensionFactory.php
+++ b/src/ExtensionFactory.php
@@ -36,7 +36,7 @@ class ExtensionFactory
     {
         return preg_replace_callback(
             '/(?:^|_)([a-z])/',
-            function($match) {
+            function ($match) {
                 return strtoupper($match[1]);
             },
             $string


### PR DESCRIPTION
Ran `composer cs-fix` against the current code base. Also modified `composer cs-fix` and `composer cs-check` to exclude `test/files` because it's files beeing cs-fixed  would break the unit tests.