### PR TITLE
Enable coding standard compliance guard in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,15 @@ language: php
 git:
   depth: 1
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
+matrix:
+  include:
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env:
+      - LINT=true
+
+  fast_finish: true
 
 sudo: false
 
@@ -18,7 +22,12 @@ cache:
 before_install:
   - composer install -n
 
-script: vendor/bin/phpunit
+script:
+  - vendor/bin/phpunit
+  # Verify coding standard compliance only once
+  - if [[ $LINT = true ]]; then
+      composer cs-check;
+    fi
 
 notifications:
   email: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for considering to contribute to `PHPMND`. While doing so please follow these guidelines:
  
  - You must follow the `PSR-2` coding standard. Please see [PSR-2](http://www.php-fig.org/psr/psr-2/) for more details.
- - You must ensure the coding standard compliance before committing or opening pull requests by running `composer cs-check` and if required `composer cs-fix` in the root directory of this repository. If one of these Composer scripts fails to run, please do a `composer update` and rerun it.
+ - You must ensure the coding standard compliance before committing or opening pull requests by running `composer cs-check` and if required `composer cs-fix` in the root directory of this repository. If one of these Composer scripts fails to run, please do a `composer update` and rerun it. In case you miss this manual check, Travis CI will enforce it and you should fix the detected coding standard violations.
  - All non trivial features or bugfixes must have an associated issue for discussion. If you want to work on an issue that is already created, please leave a comment on it indicating that you are working on it.
  - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
  - Add tests for features or bugfixes touching `src` code if you want to increase the chance of your contribution being merged.

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   "bin": ["bin/phpmnd"],
   "scripts": {
     "test": "phpunit",
-    "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/files",
+    "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/files",
     "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/files"
   },
   "extra": {


### PR DESCRIPTION
This is just a proof of concept for now.

Since there won't be any usage of [xCIs](https://github.com/povils/phpmnd/issues/25) to guard coding standard violations, utilise `composer cs-check` in Travis CI. The `composer cs-check` is only run against a single version i.e. `7.1` to keep the build fast.

If this gets an okay, I'll remove the on purpose added coding standard violation.