### PR TITLE
Fix path when installed as composer require - fixes #45

### DIFF
--- a/bin/phpmnd
+++ b/bin/phpmnd
@@ -2,36 +2,37 @@
 <?php
 
 if (version_compare('5.6.0', PHP_VERSION, '>')) {
-   fwrite(
-       STDERR,
-       sprintf(
+    fwrite(
+        STDERR,
+        sprintf(
            'This version of PHPMND is supported on PHP 5.6, PHP 7.0, and PHP 7.1.' . PHP_EOL .
            'You are using PHP %s%s.' . PHP_EOL,
            PHP_VERSION,
            defined('PHP_BINARY') ? ' (' . PHP_BINARY . ')' : ''
-       )
-   );
-   exit(1);
+        )
+    );
+    exit(1);
 }
 
 $loaded = false;
 $autoloads = [
+    __DIR__ . '/../../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
 ];
 foreach ($autoloads as $file) {
-   if (file_exists($file)) {
-      require_once $file;
-      $loaded = true;
-      break;
-   }
+    if (file_exists($file)) {
+        require_once $file;
+        $loaded = true;
+        break;
+    }
 }
 
 if (false === $loaded) {
-   exit(
-       'You need to set up the project dependencies using the following commands:' . PHP_EOL .
-       'wget http://getcomposer.org/composer.phar' . PHP_EOL .
-       'php composer.phar install' . PHP_EOL
-   );
+    exit(
+        'You need to set up the project dependencies using the following commands:' . PHP_EOL .
+        'wget http://getcomposer.org/composer.phar' . PHP_EOL .
+        'php composer.phar install' . PHP_EOL
+    );
 }
 ini_set('xdebug.max_nesting_level', 10000);
 


### PR DESCRIPTION
See #45 

Note: There's a few spacing fixes included (7 spaces vs 8 expected for tabbing).