### PR TITLE
Enable Windows Update service for Appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,8 @@ init:
 
 install:
     - IF EXIST c:\tools\php (SET PHP=0)
+    # Enable Windows update service
+    - ps: Set-Service wuauserv -StartupType Manual
     # Install PHP
     - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
     - cd c:\tools\php


### PR DESCRIPTION
Resolves some occasional failures in installing PHP where choco has a dependency on something from Windows Update being installed. It's disabled by default on Appveyor (presumably they do it manually from time to time, but not good enough for us here).