### PR TITLE
Fixing exit code

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -74,6 +74,6 @@ class Application extends BaseApplication
             $input = new ArrayInput(['--help']);
         }
 
-        parent::doRun($input, $output);
+        return parent::doRun($input, $output);
     }
 }


### PR DESCRIPTION
Code status wasn't returned from `Application::doRun`:
```bash
$ bin/phpmnd --non-zero-exit-on-violation test.php
phpmnd 1.1.0 by Povilas Susinskas


--------------------------------------------------------------------------------

test.php:9. Magic number: 42
  > 9|         if ($x > 42) {

--------------------------------------------------------------------------------

Total of Magic Numbers: 1
Time: 57 ms, Memory: 7.50MB
$ echo $?
1
```