### PR TITLE
--exclude-name is actually called --exclude-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [v1.0.2] - 2017-04-25
 ### Added
 - Add `--exclude-path` option.
-- Add `--exclude-name` option.
+- Add `--exclude-file` option.
 - Add `--ignore-funcs` option.
 - Add total magic number count in output result.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The ``--exclude`` option will exclude a directory from code analysis (must be re
 
 The ``--exclude-path`` option will exclude path from code analysis (must be relative to source) (multiple values allowed)
 
-The ``--exclude-name`` option will exclude file from code analysis (multiple values allowed)
+The ``--exclude-file`` option will exclude file from code analysis (multiple values allowed)
 
 The ``--suffixes`` comma separated option of valid source code filename extensions.
 


### PR DESCRIPTION
As the title says, the option `--exclude-name` is actually called `--exclude-file`.