### PR TITLE
Update the php timer dep to v2 and use new timer class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ git:
 
 matrix:
   include:
-    - php: 5.6
-    - php: 7.0
     - php: 7.1
     - php: 7.2
       env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ environment:
     php_ver_target: 7.2
   - dependencies: highest
     php_ver_target: 7.1
-  - dependencies: highest
-    php_ver_target: 7.0
-  - dependencies: highest
-    php_ver_target: 5.6
 
 cache: # cache is cleared when linked file is modified
     - '%LOCALAPPDATA%\Composer\files -> composer.lock'

--- a/bin/phpmnd
+++ b/bin/phpmnd
@@ -1,11 +1,11 @@
 #!/usr/bin/env php
 <?php
 
-if (version_compare('5.6.0', PHP_VERSION, '>')) {
+if (version_compare('7.1.0', PHP_VERSION, '>')) {
     fwrite(
         STDERR,
         sprintf(
-           'This version of PHPMND is supported on PHP 5.6, PHP 7.0, and PHP 7.1.' . PHP_EOL .
+           'This version of PHPMND is supported on PHP 7.1.' . PHP_EOL .
            'You are using PHP %s%s.' . PHP_EOL,
            PHP_VERSION,
            defined('PHP_BINARY') ? ' (' . PHP_BINARY . ')' : ''

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "issues": "https://github.com/povils/phpmnd/issues"
   },
   "require": {
-    "php": "^5.6|^7.0",
+    "php": "^7.1",
     "symfony/console": "^2.4 || ^3.0 || ^4.0",
     "symfony/finder": "^2.2 || ^3.0 || ^4.0",
     "nikic/php-parser": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     "symfony/finder": "^2.2 || ^3.0 || ^4.0",
     "nikic/php-parser": "^3.0",
     "jakub-onderka/php-console-highlighter": "^0.3.2",
-    "phpunit/php-timer": "^1.0"
+    "phpunit/php-timer": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7 || ^6.0",
+    "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
     "squizlabs/php_codesniffer": "^2.8.1"
   },
   "autoload": {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -8,6 +8,7 @@ use Povils\PHPMND\FileReportList;
 use Povils\PHPMND\HintList;
 use Povils\PHPMND\PHPFinder;
 use Povils\PHPMND\Printer;
+use SebastianBergmann\Timer\Timer;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
@@ -162,7 +163,7 @@ class Command extends BaseCommand
         if ($output->getVerbosity() !== OutputInterface::VERBOSITY_QUIET) {
             $output->writeln('');
             $printer->printData($output, $fileReportList, $hintList);
-            $output->writeln('<info>' . \PHP_Timer::resourceUsage() . '</info>');
+            $output->writeln('<info>' . Timer::resourceUsage() . '</info>');
         }
 
         if ($input->getOption('non-zero-exit-on-violation') && $fileReportList->hasMagicNumbers()) {


### PR DESCRIPTION
#64 Updated the version to 2 and updated the usage in the command class. Also added support for phpunit 7.

Let me know if there's a better way to do this as this might require a major release? 

All the tests pass 
```
PHPUnit 7.0.0 by Sebastian Bergmann and contributors.

.......................                                           23 / 23 (100%)

Time: 102 ms, Memory: 8.00MB

OK (23 tests, 31 assertions)
```

Looks like this will drop support for 5.6 and 7.0
