### PR TITLE
Add compatibility with phpunit/php-timer 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     "symfony/finder": "^2.2 || ^3.0 || ^4.0",
     "nikic/php-parser": "^3.0",
     "jakub-onderka/php-console-highlighter": "^0.3.2",
-    "phpunit/php-timer": "^1.0"
+    "phpunit/php-timer": "^1.0 || ^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7 || ^6.0",
+    "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
     "squizlabs/php_codesniffer": "^2.8.1"
   },
   "autoload": {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -8,6 +8,7 @@ use Povils\PHPMND\FileReportList;
 use Povils\PHPMND\HintList;
 use Povils\PHPMND\PHPFinder;
 use Povils\PHPMND\Printer;
+use SebastianBergmann\Timer\Timer;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
@@ -162,7 +163,12 @@ class Command extends BaseCommand
         if ($output->getVerbosity() !== OutputInterface::VERBOSITY_QUIET) {
             $output->writeln('');
             $printer->printData($output, $fileReportList, $hintList);
-            $output->writeln('<info>' . \PHP_Timer::resourceUsage() . '</info>');
+
+            $resourceUsage = class_exists(Timer::class)
+                ? Timer::resourceUsage()
+                : \PHP_Timer::resourceUsage();
+
+            $output->writeln('<info>' . $resourceUsage . '</info>');
         }
 
         if ($input->getOption('non-zero-exit-on-violation') && $fileReportList->hasMagicNumbers()) {


### PR DESCRIPTION
This change allows phpmnd to be installed alongside packages that depends on phpunit/php-timer 2.x (e.g. PHPUnit 7.0).