### PR TITLE
Allow array mappings

### DIFF
--- a/src/Extension/ArrayMappingExtension.php
+++ b/src/Extension/ArrayMappingExtension.php
@@ -28,7 +28,7 @@ class ArrayMappingExtension implements Extension
     {
         $parent = $node->getAttribute('parent');
 
-        return 
+        return
             $parent instanceof ArrayItem &&
             !($parent->key instanceof String_);
         ;

--- a/src/Extension/ArrayMappingExtension.php
+++ b/src/Extension/ArrayMappingExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Povils\PHPMND\Extension;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+
+/**
+ * Class ArrayMappingExtension
+ *
+ * @package Povils\PHPMND\Extension
+ */
+class ArrayMappingExtension implements Extension
+{
+    /**
+     * @inheritdoc
+     */
+    public function getName()
+    {
+        return 'array_mapping';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function extend(Node $node)
+    {
+        $parent = $node->getAttribute('parent');
+
+        return 
+            $parent instanceof ArrayItem &&
+            !($parent->key instanceof String_);
+        ;
+    }
+}

--- a/src/ExtensionResolver.php
+++ b/src/ExtensionResolver.php
@@ -4,6 +4,7 @@ namespace Povils\PHPMND;
 
 use Povils\PHPMND\Extension\ArgumentExtension;
 use Povils\PHPMND\Extension\ArrayExtension;
+use Povils\PHPMND\Extension\ArrayMappingExtension;
 use Povils\PHPMND\Extension\AssignExtension;
 use Povils\PHPMND\Extension\ConditionExtension;
 use Povils\PHPMND\Extension\DefaultParameterExtension;
@@ -83,6 +84,7 @@ class ExtensionResolver
                 [
                     new ArgumentExtension,
                     new ArrayExtension,
+                    new ArrayMappingExtension,
                     new AssignExtension,
                     new DefaultParameterExtension,
                     new OperationExtension,

--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -6,6 +6,7 @@ use Povils\PHPMND\Console\Option;
 use Povils\PHPMND\Detector;
 use Povils\PHPMND\Extension\ArgumentExtension;
 use Povils\PHPMND\Extension\ArrayExtension;
+use Povils\PHPMND\Extension\ArrayMappingExtension;
 use Povils\PHPMND\Extension\AssignExtension;
 use Povils\PHPMND\Extension\ConditionExtension;
 use Povils\PHPMND\Extension\DefaultParameterExtension;
@@ -56,7 +57,7 @@ class DetectorTest extends TestCase
                     'value' => 18,
                 ],
                 [
-                    'line' => 47,
+                    'line' => 49,
                     'value' => -2,
                 ],
             ],
@@ -150,7 +151,7 @@ class DetectorTest extends TestCase
 
         $this->assertContains(
             [
-                'line' => 37,
+                'line' => 39,
                 'value' => 15,
             ],
             $fileReport->getEntries()
@@ -207,7 +208,7 @@ class DetectorTest extends TestCase
 
         $this->assertContains(
             [
-                'line' => 43,
+                'line' => 45,
                 'value' => 'string',
             ],
             $fileReport->getEntries()
@@ -244,6 +245,40 @@ class DetectorTest extends TestCase
 
         $this->assertTrue($hintList->hasHints());
         $this->assertSame(['TEST_1::TEST_1'], $hintList->getHintsByValue(3));
+    }
+
+    public function testDetectArrayMappings()
+    {
+        $option = $this->createOption();
+        $option->setExtensions([new ArrayMappingExtension]);
+
+        $detector = $this->createDetector($option);
+
+        $fileReport = $detector->detect(FileReportTest::getTestFile('test_1'));
+
+        $this->assertContains(
+            [
+                'line' => 32,
+                'value' => 18,
+            ],
+            $fileReport->getEntries()
+        );
+
+        $this->assertContains(
+            [
+                'line' => 33,
+                'value' => 1234,
+            ],
+            $fileReport->getEntries()
+        );
+
+        $this->assertNotContains(
+            [
+                'line' => 30,
+                'value' => 13,
+            ],
+            $fileReport->getEntries()
+        );
     }
 
     /**

--- a/tests/files/test_1.php
+++ b/tests/files/test_1.php
@@ -29,6 +29,8 @@ class TEST_1
          'name' => 'Name',
          'age' => 13,
          'adult' => $input > 18,
+         18,
+         123 => 1234,
       ];
 
       if ($input > 1);


### PR DESCRIPTION
Example

[
    'ok => 200,
    'not found' => 404,
];

A non string argument or a generated key will still fail

Example

[ 1234 => 1235 ]
or
[ 1234 ]