### PR TITLE
Add function typehints and clean up composer json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
   },
   "require": {
     "php": "^7.1",
-    "symfony/console": "^2.4 || ^3.0 || ^4.0",
-    "symfony/finder": "^2.2 || ^3.0 || ^4.0",
-    "nikic/php-parser": "^3.0 || ^4.0",
+    "symfony/console": "^4.0",
+    "symfony/finder": "^4.0",
+    "nikic/php-parser": "^4.0",
     "jakub-onderka/php-console-highlighter": "^0.3.2",
-    "phpunit/php-timer": "^1.0 || ^2.0"
+    "phpunit/php-timer": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7.10 || ^6.0 || ^7.0",
+    "phpunit/phpunit": "^7.0",
     "squizlabs/php_codesniffer": "^2.8.1"
   },
   "autoload": {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -4,6 +4,7 @@ namespace Povils\PHPMND\Console;
 
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -25,7 +26,7 @@ class Application extends BaseApplication
     /**
      * @inheritdoc
      */
-    protected function getCommandName(InputInterface $input)
+    protected function getCommandName(InputInterface $input): string
     {
         return self::COMMAND_NAME;
     }
@@ -33,7 +34,7 @@ class Application extends BaseApplication
     /**
      * @inheritdoc
      */
-    protected function getDefaultCommands()
+    protected function getDefaultCommands(): array
     {
         $defaultCommands = parent::getDefaultCommands();
         $defaultCommands[] = new Command;
@@ -44,7 +45,7 @@ class Application extends BaseApplication
     /**
      * @inheritdoc
      */
-    public function getDefinition()
+    public function getDefinition(): InputDefinition
     {
         $inputDefinition = parent::getDefinition();
         $inputDefinition->setArguments();
@@ -55,7 +56,7 @@ class Application extends BaseApplication
     /**
      * @inheritdoc
      */
-    public function doRun(InputInterface $input, OutputInterface $output)
+    public function doRun(InputInterface $input, OutputInterface $output): int
     {
         if (false === $input->hasParameterOption('--quiet')) {
             $output->write(
@@ -67,7 +68,7 @@ class Application extends BaseApplication
         }
 
         if ($input->hasParameterOption('--version') || $input->hasParameterOption('-V')) {
-            exit;
+            return Command::EXIT_CODE_SUCCESS;
         }
 
         if (null === $input->getFirstArgument()) {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -23,17 +23,11 @@ class Application extends BaseApplication
         parent::__construct('phpmnd', self::VERSION);
     }
 
-    /**
-     * @inheritdoc
-     */
     protected function getCommandName(InputInterface $input): string
     {
         return self::COMMAND_NAME;
     }
 
-    /**
-     * @inheritdoc
-     */
     protected function getDefaultCommands(): array
     {
         $defaultCommands = parent::getDefaultCommands();
@@ -42,9 +36,6 @@ class Application extends BaseApplication
         return $defaultCommands;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getDefinition(): InputDefinition
     {
         $inputDefinition = parent::getDefinition();
@@ -53,9 +44,6 @@ class Application extends BaseApplication
         return $inputDefinition;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
         if (false === $input->hasParameterOption('--quiet')) {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -26,9 +26,6 @@ class Command extends BaseCommand
     const EXIT_CODE_SUCCESS = 0;
     const EXIT_CODE_FAILURE = 1;
 
-    /**
-     * @inheritdoc
-     */
     protected function configure(): void
     {
         $this
@@ -137,9 +134,6 @@ class Command extends BaseCommand
         ;
     }
 
-    /**
-     * @inheritdoc
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $finder = $this->createFinder($input);
@@ -199,11 +193,6 @@ class Command extends BaseCommand
         return self::EXIT_CODE_SUCCESS;
     }
 
-    /**
-     * @param InputInterface $input
-     * @return Option
-     * @throws \Exception
-     */
     private function createOption(InputInterface $input): Option
     {
         $option = new Option;
@@ -221,12 +210,6 @@ class Command extends BaseCommand
         return $option;
     }
 
-    /**
-     * @param InputInterface $input
-     * @param string $option
-     *
-     * @return array
-     */
     private function getCSVOption(InputInterface $input, string $option): array
     {
         $result = $input->getOption($option);
@@ -246,11 +229,6 @@ class Command extends BaseCommand
         return $result;
     }
 
-    /**
-     * @param InputInterface $input
-     *
-     * @return PHPFinder
-     */
     protected function createFinder(InputInterface $input): PHPFinder
     {
         return new PHPFinder(
@@ -262,11 +240,6 @@ class Command extends BaseCommand
         );
     }
 
-    /**
-     * @param string $value
-     *
-     * @return int|float|string
-     */
     private function castToNumber(string $value)
     {
         if (is_numeric($value)) {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -29,7 +29,7 @@ class Command extends BaseCommand
     /**
      * @inheritdoc
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('phpmnd')
@@ -140,7 +140,7 @@ class Command extends BaseCommand
     /**
      * @inheritdoc
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $finder = $this->createFinder($input);
 
@@ -204,7 +204,7 @@ class Command extends BaseCommand
      * @return Option
      * @throws \Exception
      */
-    private function createOption(InputInterface $input)
+    private function createOption(InputInterface $input): Option
     {
         $option = new Option;
         $option->setIgnoreNumbers(array_map([$this, 'castToNumber'], $this->getCSVOption($input, 'ignore-numbers')));
@@ -227,7 +227,7 @@ class Command extends BaseCommand
      *
      * @return array
      */
-    private function getCSVOption(InputInterface $input, $option)
+    private function getCSVOption(InputInterface $input, string $option): array
     {
         $result = $input->getOption($option);
         if (false === is_array($result)) {
@@ -251,7 +251,7 @@ class Command extends BaseCommand
      *
      * @return PHPFinder
      */
-    protected function createFinder(InputInterface $input)
+    protected function createFinder(InputInterface $input): PHPFinder
     {
         return new PHPFinder(
             $input->getArgument('directory'),
@@ -267,7 +267,7 @@ class Command extends BaseCommand
      *
      * @return int|float|string
      */
-    private function castToNumber($value)
+    private function castToNumber(string $value)
     {
         if (is_numeric($value)) {
             $value += 0; // '2' -> (int) 2, '2.' -> (float) 2.0

--- a/src/Console/Option.php
+++ b/src/Console/Option.php
@@ -49,129 +49,81 @@ class Option
      */
     private $allowArrayMapping = false;
 
-    /**
-     * @param Extension[] $extensions
-     */
     public function setExtensions(array $extensions)
     {
         $this->extensions = $extensions;
     }
 
-    /**
-     * @return Extension[]
-     */
     public function getExtensions(): array
     {
         return $this->extensions;
     }
 
-    /**
-     * @param array $ignoreNumbers
-     */
     public function setIgnoreNumbers(array $ignoreNumbers)
     {
         $this->ignoreNumbers = array_merge($this->ignoreNumbers, $ignoreNumbers);
     }
 
-    /**
-     * @return array
-     */
     public function getIgnoreNumbers(): array
     {
         return $this->ignoreNumbers;
     }
 
-    /**
-     * @param array $ignoreFuncs
-     */
     public function setIgnoreFuncs(array $ignoreFuncs)
     {
         $this->ignoreFuncs = $ignoreFuncs;
     }
 
-    /**
-     * @return array
-     */
     public function getIgnoreFuncs(): array
     {
         return $this->ignoreFuncs;
     }
 
-    /**
-     * @return bool
-     */
     public function includeStrings(): ?bool
     {
         return $this->includeStrings;
     }
 
-    /**
-     * @param bool $includeStrings
-     */
     public function setIncludeStrings(?bool $includeStrings)
     {
         $this->includeStrings = $includeStrings;
     }
 
-    /**
-     * @return array
-     */
     public function getIgnoreStrings(): array
     {
         return $this->ignoreStrings;
     }
 
-    /**
-     * @param array $ignoreStrings
-     */
     public function setIgnoreStrings(array $ignoreStrings)
     {
         $this->ignoreStrings = array_merge($this->ignoreStrings, $ignoreStrings);
     }
 
-    /**
-     * @return boolean
-     */
     public function giveHint(): bool
     {
         return $this->giveHint;
     }
 
-    /**
-     * @param boolean $giveHint
-     */
     public function setGiveHint(bool $giveHint)
     {
         $this->giveHint = $giveHint;
     }
 
-    /**
-     * @return bool
-     */
     public function includeNumericStrings(): ?bool
     {
         return $this->includeNumericStrings;
     }
 
-    /**
-     * @param bool $includeNumericStrings
-     */
     public function setIncludeNumericStrings(?bool $includeNumericStrings)
     {
         $this->includeNumericStrings = $includeNumericStrings;
     }
 
-    /**
-     * @return bool
-     */
     public function allowArrayMapping(): ?bool
     {
         return $this->allowArrayMapping;
     }
 
-    /**
-     * @param bool $allowArrayMapping
-     */
     public function setAllowArrayMapping(?bool $allowArrayMapping)
     {
         $this->allowArrayMapping = $allowArrayMapping;

--- a/src/Console/Option.php
+++ b/src/Console/Option.php
@@ -60,7 +60,7 @@ class Option
     /**
      * @return Extension[]
      */
-    public function getExtensions()
+    public function getExtensions(): array
     {
         return $this->extensions;
     }
@@ -76,7 +76,7 @@ class Option
     /**
      * @return array
      */
-    public function getIgnoreNumbers()
+    public function getIgnoreNumbers(): array
     {
         return $this->ignoreNumbers;
     }
@@ -92,7 +92,7 @@ class Option
     /**
      * @return array
      */
-    public function getIgnoreFuncs()
+    public function getIgnoreFuncs(): array
     {
         return $this->ignoreFuncs;
     }
@@ -100,7 +100,7 @@ class Option
     /**
      * @return bool
      */
-    public function includeStrings()
+    public function includeStrings(): ?bool
     {
         return $this->includeStrings;
     }
@@ -108,7 +108,7 @@ class Option
     /**
      * @param bool $includeStrings
      */
-    public function setIncludeStrings($includeStrings)
+    public function setIncludeStrings(?bool $includeStrings)
     {
         $this->includeStrings = $includeStrings;
     }
@@ -116,7 +116,7 @@ class Option
     /**
      * @return array
      */
-    public function getIgnoreStrings()
+    public function getIgnoreStrings(): array
     {
         return $this->ignoreStrings;
     }
@@ -132,7 +132,7 @@ class Option
     /**
      * @return boolean
      */
-    public function giveHint()
+    public function giveHint(): bool
     {
         return $this->giveHint;
     }
@@ -140,7 +140,7 @@ class Option
     /**
      * @param boolean $giveHint
      */
-    public function setGiveHint($giveHint)
+    public function setGiveHint(bool $giveHint)
     {
         $this->giveHint = $giveHint;
     }
@@ -148,7 +148,7 @@ class Option
     /**
      * @return bool
      */
-    public function includeNumericStrings()
+    public function includeNumericStrings(): ?bool
     {
         return $this->includeNumericStrings;
     }
@@ -156,7 +156,7 @@ class Option
     /**
      * @param bool $includeNumericStrings
      */
-    public function setIncludeNumericStrings($includeNumericStrings)
+    public function setIncludeNumericStrings(?bool $includeNumericStrings)
     {
         $this->includeNumericStrings = $includeNumericStrings;
     }
@@ -164,7 +164,7 @@ class Option
     /**
      * @return bool
      */
-    public function allowArrayMapping()
+    public function allowArrayMapping(): ?bool
     {
         return $this->allowArrayMapping;
     }
@@ -172,7 +172,7 @@ class Option
     /**
      * @param bool $allowArrayMapping
      */
-    public function setAllowArrayMapping($allowArrayMapping)
+    public function setAllowArrayMapping(?bool $allowArrayMapping)
     {
         $this->allowArrayMapping = $allowArrayMapping;
     }

--- a/src/Detector.php
+++ b/src/Detector.php
@@ -27,21 +27,12 @@ class Detector
      */
     private $hintList;
 
-    /**
-     * @param Option   $option
-     * @param HintList $hintList
-     */
     public function __construct(Option $option, HintList $hintList)
     {
         $this->option = $option;
         $this->hintList = $hintList;
     }
 
-    /**
-     * @param SplFileInfo $file
-     *
-     * @return FileReport
-     */
     public function detect(SplFileInfo $file): FileReport
     {
         $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);

--- a/src/Detector.php
+++ b/src/Detector.php
@@ -42,7 +42,7 @@ class Detector
      *
      * @return FileReport
      */
-    public function detect(SplFileInfo $file)
+    public function detect(SplFileInfo $file): FileReport
     {
         $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
         $traverser = new NodeTraverser();

--- a/src/Extension/ArgumentExtension.php
+++ b/src/Extension/ArgumentExtension.php
@@ -9,26 +9,16 @@ use PhpParser\Node\Name;
 
 class ArgumentExtension extends Extension
 {
-    /**
-     * @inheritdoc
-     */
     public function getName(): string
     {
         return 'argument';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof Arg && false === $this->ignoreFunc($node);
     }
 
-    /**
-     * @param Node $node
-     * @return bool
-     */
     private function ignoreFunc(Node $node): bool
     {
         /** @var FuncCall $funcCallNode */

--- a/src/Extension/ArgumentExtension.php
+++ b/src/Extension/ArgumentExtension.php
@@ -12,7 +12,7 @@ class ArgumentExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function getName()
+    public function getName(): string
     {
         return 'argument';
     }
@@ -20,7 +20,7 @@ class ArgumentExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function extend(Node $node)
+    public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof Arg && false === $this->ignoreFunc($node);
     }
@@ -29,7 +29,7 @@ class ArgumentExtension extends Extension
      * @param Node $node
      * @return bool
      */
-    private function ignoreFunc(Node $node)
+    private function ignoreFunc(Node $node): bool
     {
         /** @var FuncCall $funcCallNode */
         $funcCallNode = $node->getAttribute('parent')->getAttribute('parent');

--- a/src/Extension/ArrayExtension.php
+++ b/src/Extension/ArrayExtension.php
@@ -11,7 +11,7 @@ class ArrayExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function getName()
+    public function getName(): string
     {
         return 'array';
     }
@@ -19,7 +19,7 @@ class ArrayExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function extend(Node $node)
+    public function extend(Node $node): bool
     {
         $parent = $node->getAttribute('parent');
 
@@ -29,7 +29,7 @@ class ArrayExtension extends Extension
     /**
      * @inheritdoc
      */
-    private function ignoreArray(ArrayItem $node)
+    private function ignoreArray(ArrayItem $node): bool
     {
         $arrayKey = $node->key;
         

--- a/src/Extension/ArrayExtension.php
+++ b/src/Extension/ArrayExtension.php
@@ -8,17 +8,11 @@ use PhpParser\Node\Scalar\String_;
 
 class ArrayExtension extends Extension
 {
-    /**
-     * @inheritdoc
-     */
     public function getName(): string
     {
         return 'array';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function extend(Node $node): bool
     {
         $parent = $node->getAttribute('parent');
@@ -26,9 +20,6 @@ class ArrayExtension extends Extension
         return $parent instanceof ArrayItem && false === $this->ignoreArray($parent);
     }
 
-    /**
-     * @inheritdoc
-     */
     private function ignoreArray(ArrayItem $node): bool
     {
         $arrayKey = $node->key;

--- a/src/Extension/AssignExtension.php
+++ b/src/Extension/AssignExtension.php
@@ -7,17 +7,11 @@ use PhpParser\Node\Expr\Assign;
 
 class AssignExtension extends Extension
 {
-    /**
-     * @inheritdoc
-     */
     public function getName(): string
     {
         return 'assign';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof Assign;

--- a/src/Extension/AssignExtension.php
+++ b/src/Extension/AssignExtension.php
@@ -10,7 +10,7 @@ class AssignExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function getName()
+    public function getName(): string
     {
         return 'assign';
     }
@@ -18,7 +18,7 @@ class AssignExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function extend(Node $node)
+    public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof Assign;
     }

--- a/src/Extension/ConditionExtension.php
+++ b/src/Extension/ConditionExtension.php
@@ -21,17 +21,11 @@ use PhpParser\Node\Expr\ConstFetch;
 
 class ConditionExtension extends Extension
 {
-    /**
-     * @inheritdoc
-     */
     public function getName(): string
     {
         return 'condition';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function extend(Node $node): bool
     {
         return
@@ -40,11 +34,6 @@ class ConditionExtension extends Extension
             false === $this->comparesToConst($node->getAttribute('parent'));
     }
 
-    /**
-     * @param Node $node
-     *
-     * @return bool
-     */
     private function isCondition(Node $node): bool
     {
         return
@@ -79,11 +68,6 @@ class ConditionExtension extends Extension
             );
     }
 
-    /**
-     * @param BinaryOp $node
-     *
-     * @return bool
-     */
     private function comparesToConst(BinaryOp $node): bool
     {
         return

--- a/src/Extension/ConditionExtension.php
+++ b/src/Extension/ConditionExtension.php
@@ -24,7 +24,7 @@ class ConditionExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function getName()
+    public function getName(): string
     {
         return 'condition';
     }
@@ -32,7 +32,7 @@ class ConditionExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function extend(Node $node)
+    public function extend(Node $node): bool
     {
         return
             $this->isCondition($node->getAttribute('parent'))
@@ -45,7 +45,7 @@ class ConditionExtension extends Extension
      *
      * @return bool
      */
-    private function isCondition($node)
+    private function isCondition(Node $node): bool
     {
         return
             $node instanceof BinaryOp
@@ -84,7 +84,7 @@ class ConditionExtension extends Extension
      *
      * @return bool
      */
-    private function comparesToConst($node)
+    private function comparesToConst(BinaryOp $node): bool
     {
         return
             $node instanceof BinaryOp

--- a/src/Extension/DefaultParameterExtension.php
+++ b/src/Extension/DefaultParameterExtension.php
@@ -10,7 +10,7 @@ class DefaultParameterExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function getName()
+    public function getName(): string
     {
         return 'default_parameter';
     }
@@ -18,7 +18,7 @@ class DefaultParameterExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function extend(Node $node)
+    public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof Param;
     }

--- a/src/Extension/DefaultParameterExtension.php
+++ b/src/Extension/DefaultParameterExtension.php
@@ -7,17 +7,11 @@ use PhpParser\Node\Param;
 
 class DefaultParameterExtension extends Extension
 {
-    /**
-     * @inheritdoc
-     */
     public function getName(): string
     {
         return 'default_parameter';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof Param;

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -15,21 +15,10 @@ abstract class Extension
      */
     protected $option;
 
-    /**
-     * @param Node $node
-     *
-     * @return bool
-     */
     abstract public function extend(Node $node): bool;
 
-    /**
-     * @return string
-     */
     abstract public function getName(): string;
 
-    /**
-     * @param Option $option
-     */
     public function setOption(Option $option)
     {
         $this->option = $option;

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -20,12 +20,12 @@ abstract class Extension
      *
      * @return bool
      */
-    abstract public function extend(Node $node);
+    abstract public function extend(Node $node): bool;
 
     /**
      * @return string
      */
-    abstract public function getName();
+    abstract public function getName(): string;
 
     /**
      * @param Option $option

--- a/src/Extension/OperationExtension.php
+++ b/src/Extension/OperationExtension.php
@@ -17,7 +17,7 @@ class OperationExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function getName()
+    public function getName(): string
     {
         return 'operation';
     }
@@ -25,7 +25,7 @@ class OperationExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function extend(Node $node)
+    public function extend(Node $node): bool
     {
         $parentNode = $node->getAttribute('parent');
 

--- a/src/Extension/OperationExtension.php
+++ b/src/Extension/OperationExtension.php
@@ -14,17 +14,11 @@ use PhpParser\Node\Expr\BinaryOp\ShiftRight;
 
 class OperationExtension extends Extension
 {
-    /**
-     * @inheritdoc
-     */
     public function getName(): string
     {
         return 'operation';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function extend(Node $node): bool
     {
         $parentNode = $node->getAttribute('parent');

--- a/src/Extension/PropertyExtension.php
+++ b/src/Extension/PropertyExtension.php
@@ -10,7 +10,7 @@ class PropertyExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function getName()
+    public function getName(): string
     {
         return 'property';
     }
@@ -18,7 +18,7 @@ class PropertyExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function extend(Node $node)
+    public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof PropertyProperty;
     }

--- a/src/Extension/PropertyExtension.php
+++ b/src/Extension/PropertyExtension.php
@@ -7,17 +7,11 @@ use PhpParser\Node\Stmt\PropertyProperty;
 
 class PropertyExtension extends Extension
 {
-    /**
-     * @inheritdoc
-     */
     public function getName(): string
     {
         return 'property';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof PropertyProperty;

--- a/src/Extension/ReturnExtension.php
+++ b/src/Extension/ReturnExtension.php
@@ -10,7 +10,7 @@ class ReturnExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function getName()
+    public function getName(): string
     {
         return 'return';
     }
@@ -18,7 +18,7 @@ class ReturnExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function extend(Node $node)
+    public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof Return_;
     }

--- a/src/Extension/ReturnExtension.php
+++ b/src/Extension/ReturnExtension.php
@@ -7,17 +7,11 @@ use PhpParser\Node\Stmt\Return_;
 
 class ReturnExtension extends Extension
 {
-    /**
-     * @inheritdoc
-     */
     public function getName(): string
     {
         return 'return';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof Return_;

--- a/src/Extension/SwitchCaseExtension.php
+++ b/src/Extension/SwitchCaseExtension.php
@@ -10,7 +10,7 @@ class SwitchCaseExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function getName()
+    public function getName(): string
     {
         return 'switch_case';
     }
@@ -18,7 +18,7 @@ class SwitchCaseExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function extend(Node $node)
+    public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof Case_;
     }

--- a/src/Extension/SwitchCaseExtension.php
+++ b/src/Extension/SwitchCaseExtension.php
@@ -7,17 +7,11 @@ use PhpParser\Node\Stmt\Case_;
 
 class SwitchCaseExtension extends Extension
 {
-    /**
-     * @inheritdoc
-     */
     public function getName(): string
     {
         return 'switch_case';
     }
 
-    /**
-     * @inheritdoc
-     */
     public function extend(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof Case_;

--- a/src/ExtensionResolver.php
+++ b/src/ExtensionResolver.php
@@ -37,7 +37,7 @@ class ExtensionResolver
      */
     private $resolvedExtensions = [];
 
-    public function resolve(array $extensionNames)
+    public function resolve(array $extensionNames): array
     {
         $this->resolvedExtensions = $this->defaults();
         if (($allKey = array_search(self::ALL_EXTENSIONS, $extensionNames)) !== false) {
@@ -60,7 +60,7 @@ class ExtensionResolver
     /**
      * @return Extension[]
      */
-    public function defaults()
+    public function defaults(): array
     {
         if (null === $this->defaultExtensions) {
             $this->defaultExtensions = [
@@ -76,7 +76,7 @@ class ExtensionResolver
     /**
      * @return Extension[]
      */
-    public function all()
+    public function all(): array
     {
         if (null === $this->allExtensions) {
             $this->allExtensions = array_merge(
@@ -98,7 +98,7 @@ class ExtensionResolver
     /**
      * @param string $extensionName
      */
-    private function addExtension($extensionName)
+    private function addExtension(string $extensionName): void
     {
         if ($this->exists($extensionName)) {
             foreach ($this->all() as $extension) {
@@ -116,7 +116,7 @@ class ExtensionResolver
      *
      * @throws \Exception
      */
-    private function removeExtension($extensionName)
+    private function removeExtension(string $extensionName): void
     {
         $extensionNameWithoutMinus = substr($extensionName, 1);
         if ($this->exists($extensionNameWithoutMinus)) {
@@ -136,7 +136,7 @@ class ExtensionResolver
      *
      * @throws \Exception
      */
-    private function exists($extensionName)
+    private function exists(string $extensionName): bool
     {
         foreach ($this->all() as $extension) {
             if ($extension->getName() === $extensionName) {
@@ -152,7 +152,7 @@ class ExtensionResolver
      *
      * @return bool
      */
-    private function startsWithMinus($extensionName)
+    private function startsWithMinus(string $extensionName): bool
     {
         return 0 === strpos($extensionName, '-');
     }

--- a/src/ExtensionResolver.php
+++ b/src/ExtensionResolver.php
@@ -57,9 +57,6 @@ class ExtensionResolver
         return $this->resolvedExtensions;
     }
 
-    /**
-     * @return Extension[]
-     */
     public function defaults(): array
     {
         if (null === $this->defaultExtensions) {
@@ -73,9 +70,6 @@ class ExtensionResolver
         return $this->defaultExtensions;
     }
 
-    /**
-     * @return Extension[]
-     */
     public function all(): array
     {
         if (null === $this->allExtensions) {
@@ -95,9 +89,6 @@ class ExtensionResolver
         return $this->allExtensions;
     }
 
-    /**
-     * @param string $extensionName
-     */
     private function addExtension(string $extensionName): void
     {
         if ($this->exists($extensionName)) {
@@ -111,11 +102,6 @@ class ExtensionResolver
         }
     }
 
-    /**
-     * @param string $extensionName
-     *
-     * @throws \Exception
-     */
     private function removeExtension(string $extensionName): void
     {
         $extensionNameWithoutMinus = substr($extensionName, 1);
@@ -130,12 +116,6 @@ class ExtensionResolver
         }
     }
 
-    /**
-     * @param string $extensionName
-     * @return bool
-     *
-     * @throws \Exception
-     */
     private function exists(string $extensionName): bool
     {
         foreach ($this->all() as $extension) {
@@ -147,11 +127,6 @@ class ExtensionResolver
         throw new \InvalidArgumentException(sprintf('Extension "%s" does not exist', $extensionName));
     }
 
-    /**
-     * @param string $extensionName
-     *
-     * @return bool
-     */
     private function startsWithMinus(string $extensionName): bool
     {
         return 0 === strpos($extensionName, '-');

--- a/src/FileReport.php
+++ b/src/FileReport.php
@@ -30,7 +30,7 @@ class FileReport
     /**
      * @return SplFileInfo
      */
-    public function getFile()
+    public function getFile(): SplFileInfo
     {
         return $this->file;
     }
@@ -39,7 +39,7 @@ class FileReport
      * @param int $line
      * @param int|float $value
      */
-    public function addEntry($line, $value)
+    public function addEntry(int $line, $value): void
     {
         $this->entries[] = [
             'line' => $line,
@@ -50,7 +50,7 @@ class FileReport
     /**
      * @return array
      */
-    public function getEntries()
+    public function getEntries(): array
     {
         return $this->entries;
     }
@@ -58,7 +58,7 @@ class FileReport
     /**
      * @return bool
      */
-    public function hasMagicNumbers()
+    public function hasMagicNumbers(): bool
     {
         return false === empty($this->entries);
     }

--- a/src/FileReport.php
+++ b/src/FileReport.php
@@ -27,9 +27,6 @@ class FileReport
         $this->file = $file;
     }
 
-    /**
-     * @return SplFileInfo
-     */
     public function getFile(): SplFileInfo
     {
         return $this->file;
@@ -47,17 +44,11 @@ class FileReport
         ];
     }
 
-    /**
-     * @return array
-     */
     public function getEntries(): array
     {
         return $this->entries;
     }
 
-    /**
-     * @return bool
-     */
     public function hasMagicNumbers(): bool
     {
         return false === empty($this->entries);

--- a/src/FileReportList.php
+++ b/src/FileReportList.php
@@ -17,7 +17,7 @@ class FileReportList
     /**
      * @param FileReport $fileReport
      */
-    public function addFileReport(FileReport $fileReport)
+    public function addFileReport(FileReport $fileReport): void
     {
         $this->fileReports[] = $fileReport;
     }
@@ -25,7 +25,7 @@ class FileReportList
     /**
      * @return FileReport[]
      */
-    public function getFileReports()
+    public function getFileReports(): array
     {
         return $this->fileReports;
     }
@@ -33,7 +33,7 @@ class FileReportList
     /**
      * @return bool
      */
-    public function hasMagicNumbers()
+    public function hasMagicNumbers(): bool
     {
         foreach ($this->fileReports as $fileReport) {
             if ($fileReport->hasMagicNumbers()) {

--- a/src/FileReportList.php
+++ b/src/FileReportList.php
@@ -14,25 +14,16 @@ class FileReportList
      */
     private $fileReports = [];
 
-    /**
-     * @param FileReport $fileReport
-     */
     public function addFileReport(FileReport $fileReport): void
     {
         $this->fileReports[] = $fileReport;
     }
 
-    /**
-     * @return FileReport[]
-     */
     public function getFileReports(): array
     {
         return $this->fileReports;
     }
 
-    /**
-     * @return bool
-     */
     public function hasMagicNumbers(): bool
     {
         foreach ($this->fileReports as $fileReport) {

--- a/src/HintList.php
+++ b/src/HintList.php
@@ -31,9 +31,6 @@ class HintList
         return $hints;
     }
 
-    /**
-     * @return bool
-     */
     public function hasHints(): bool
     {
         return false === empty($this->constants);

--- a/src/HintList.php
+++ b/src/HintList.php
@@ -19,7 +19,7 @@ class HintList
      *
      * @return array
      */
-    public function getHintsByValue($magicNumber)
+    public function getHintsByValue($magicNumber): array
     {
         $hints = [];
         foreach ($this->constants as $constant) {
@@ -34,7 +34,7 @@ class HintList
     /**
      * @return bool
      */
-    public function hasHints()
+    public function hasHints(): bool
     {
         return false === empty($this->constants);
     }
@@ -44,7 +44,7 @@ class HintList
      * @param string $className
      * @param string $constName
      */
-    public function addClassCont($value, $className, $constName)
+    public function addClassCont($value, string $className, string $constName): void
     {
         $this->constants[] = [
             'value' => $value,

--- a/src/PHPFinder.php
+++ b/src/PHPFinder.php
@@ -11,13 +11,6 @@ use Symfony\Component\Finder\Finder;
  */
 class PHPFinder extends Finder
 {
-    /**
-     * @param string $directory
-     * @param array  $exclude
-     * @param array  $excludePaths
-     * @param array  $excludeFiles
-     * @param array  $suffixes
-     */
     public function __construct(
         string $directory,
         array $exclude,

--- a/src/PHPFinder.php
+++ b/src/PHPFinder.php
@@ -19,7 +19,7 @@ class PHPFinder extends Finder
      * @param array  $suffixes
      */
     public function __construct(
-        $directory,
+        string $directory,
         array $exclude,
         array $excludePaths,
         array $excludeFiles,

--- a/src/Printer/Console.php
+++ b/src/Printer/Console.php
@@ -18,9 +18,6 @@ class Console implements Printer
     const LINE_LENGTH = 80;
     const TAB = 4;
 
-    /**
-     * {@inheritDoc}
-     */
     public function printData(OutputInterface $output, FileReportList $fileReportList, HintList $hintList): void
     {
         $separator = str_repeat('-', self::LINE_LENGTH);

--- a/src/Printer/Console.php
+++ b/src/Printer/Console.php
@@ -21,7 +21,7 @@ class Console implements Printer
     /**
      * {@inheritDoc}
      */
-    public function printData(OutputInterface $output, FileReportList $fileReportList, HintList $hintList)
+    public function printData(OutputInterface $output, FileReportList $fileReportList, HintList $hintList): void
     {
         $separator = str_repeat('-', self::LINE_LENGTH);
         $output->writeln(PHP_EOL . $separator . PHP_EOL);

--- a/src/Printer/Printer.php
+++ b/src/Printer/Printer.php
@@ -13,13 +13,5 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 interface Printer
 {
-    /**
-     * Render the result of the detector
-     *
-     * @param OutputInterface $output
-     * @param FileReportList  $fileReportList
-     * @param HintList        $hintList
-     * @return void
-     */
     public function printData(OutputInterface $output, FileReportList $fileReportList, HintList $hintList): void;
 }

--- a/src/Printer/Printer.php
+++ b/src/Printer/Printer.php
@@ -21,5 +21,5 @@ interface Printer
      * @param HintList        $hintList
      * @return void
      */
-    public function printData(OutputInterface $output, FileReportList $fileReportList, HintList $hintList);
+    public function printData(OutputInterface $output, FileReportList $fileReportList, HintList $hintList): void;
 }

--- a/src/Printer/Xml.php
+++ b/src/Printer/Xml.php
@@ -17,19 +17,11 @@ class Xml implements Printer
     /** @var string */
     private $outputPath;
 
-    /**
-     * Xml constructor.
-     *
-     * @param string $outputPath
-     */
     public function __construct(string $outputPath)
     {
         $this->outputPath = $outputPath;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function printData(OutputInterface $output, FileReportList $fileReportList, HintList $hintList): void
     {
         $output->writeln('Generate XML output...');

--- a/src/Printer/Xml.php
+++ b/src/Printer/Xml.php
@@ -22,7 +22,7 @@ class Xml implements Printer
      *
      * @param string $outputPath
      */
-    public function __construct($outputPath)
+    public function __construct(string $outputPath)
     {
         $this->outputPath = $outputPath;
     }
@@ -30,7 +30,7 @@ class Xml implements Printer
     /**
      * {@inheritDoc}
      */
-    public function printData(OutputInterface $output, FileReportList $fileReportList, HintList $hintList)
+    public function printData(OutputInterface $output, FileReportList $fileReportList, HintList $hintList): void
     {
         $output->writeln('Generate XML output...');
         $dom = new \DOMDocument();
@@ -97,7 +97,7 @@ class Xml implements Printer
      * @param int|string $text
      * @return array
      */
-    private function getSnippet($content, $line, $text)
+    private function getSnippet(string $content, int $line, $text): array
     {
         $content = str_replace(array("\r\n", "\r"), "\n", $content);
         $lines = explode("\n", $content);

--- a/src/Visitor/DetectorVisitor.php
+++ b/src/Visitor/DetectorVisitor.php
@@ -48,7 +48,7 @@ class DetectorVisitor extends NodeVisitorAbstract
     /**
      * @inheritdoc
      */
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): ?int
     {
         if ($node instanceof Const_) {
             return NodeTraverser::DONT_TRAVERSE_CHILDREN;
@@ -81,7 +81,7 @@ class DetectorVisitor extends NodeVisitorAbstract
      *
      * @return bool
      */
-    private function isNumber(Node $node)
+    private function isNumber(Node $node): bool
     {
         $isNumber = (
             $node instanceof LNumber ||
@@ -97,7 +97,7 @@ class DetectorVisitor extends NodeVisitorAbstract
      *
      * @return bool
      */
-    private function isString(Node $node)
+    private function isString(Node $node): bool
     {
         return $this->option->includeStrings() && $node instanceof String_ && false === $this->ignoreString($node);
     }
@@ -107,7 +107,7 @@ class DetectorVisitor extends NodeVisitorAbstract
      *
      * @return bool
      */
-    private function ignoreNumber(Node $node)
+    private function ignoreNumber(Node $node): bool
     {
         return in_array($node->value, $this->option->getIgnoreNumbers(), true);
     }
@@ -117,7 +117,7 @@ class DetectorVisitor extends NodeVisitorAbstract
      *
      * @return bool
      */
-    private function ignoreString(Node $node)
+    private function ignoreString(Node $node): bool
     {
         return in_array($node->value, $this->option->getIgnoreStrings(), true);
     }
@@ -127,7 +127,7 @@ class DetectorVisitor extends NodeVisitorAbstract
      *
      * @return bool
      */
-    private function hasSign(Node $node)
+    private function hasSign(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof UnaryMinus || $node->getAttribute('parent') instanceof UnaryPlus;
     }
@@ -137,7 +137,7 @@ class DetectorVisitor extends NodeVisitorAbstract
      *
      * @return bool
      */
-    private function isMinus(Node $node)
+    private function isMinus(Node $node): bool
     {
         return $node instanceof UnaryMinus;
     }
@@ -146,7 +146,7 @@ class DetectorVisitor extends NodeVisitorAbstract
      * @param Node $node
      * @return bool
      */
-    private function isValidNumeric(Node $node)
+    private function isValidNumeric(Node $node): bool
     {
         return $this->option->includeNumericStrings() &&
         isset($node->value) &&

--- a/src/Visitor/DetectorVisitor.php
+++ b/src/Visitor/DetectorVisitor.php
@@ -35,19 +35,12 @@ class DetectorVisitor extends NodeVisitorAbstract
      */
     private $option;
 
-    /**
-     * @param FileReport $fileReport
-     * @param Option $option
-     */
     public function __construct(FileReport $fileReport, Option $option)
     {
         $this->fileReport = $fileReport;
         $this->option = $option;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function enterNode(Node $node): ?int
     {
         if ($node instanceof Const_) {
@@ -76,11 +69,6 @@ class DetectorVisitor extends NodeVisitorAbstract
         return null;
     }
 
-    /**
-     * @param Node $node
-     *
-     * @return bool
-     */
     private function isNumber(Node $node): bool
     {
         $isNumber = (
@@ -92,61 +80,32 @@ class DetectorVisitor extends NodeVisitorAbstract
         return $isNumber && false === $this->ignoreNumber($node);
     }
 
-    /**
-     * @param Node $node
-     *
-     * @return bool
-     */
     private function isString(Node $node): bool
     {
         return $this->option->includeStrings() && $node instanceof String_ && false === $this->ignoreString($node);
     }
 
-    /**
-     * @param LNumber|DNumber|Node $node
-     *
-     * @return bool
-     */
     private function ignoreNumber(Node $node): bool
     {
         return in_array($node->value, $this->option->getIgnoreNumbers(), true);
     }
 
-    /**
-     * @param String_|Node $node
-     *
-     * @return bool
-     */
     private function ignoreString(Node $node): bool
     {
         return in_array($node->value, $this->option->getIgnoreStrings(), true);
     }
 
-    /**
-     * @param Node $node
-     *
-     * @return bool
-     */
     private function hasSign(Node $node): bool
     {
         return $node->getAttribute('parent') instanceof UnaryMinus
             || $node->getAttribute('parent') instanceof UnaryPlus;
     }
 
-    /**
-     * @param Node $node
-     *
-     * @return bool
-     */
     private function isMinus(Node $node): bool
     {
         return $node instanceof UnaryMinus;
     }
 
-    /**
-     * @param Node $node
-     * @return bool
-     */
     private function isValidNumeric(Node $node): bool
     {
         return $this->option->includeNumericStrings() &&

--- a/src/Visitor/DetectorVisitor.php
+++ b/src/Visitor/DetectorVisitor.php
@@ -129,7 +129,8 @@ class DetectorVisitor extends NodeVisitorAbstract
      */
     private function hasSign(Node $node): bool
     {
-        return $node->getAttribute('parent') instanceof UnaryMinus || $node->getAttribute('parent') instanceof UnaryPlus;
+        return $node->getAttribute('parent') instanceof UnaryMinus
+            || $node->getAttribute('parent') instanceof UnaryPlus;
     }
 
     /**

--- a/src/Visitor/HintVisitor.php
+++ b/src/Visitor/HintVisitor.php
@@ -23,17 +23,11 @@ class HintVisitor extends NodeVisitorAbstract
      */
     private $hintList;
 
-    /**
-     * @param HintList $hintList
-     */
     public function __construct(HintList $hintList)
     {
         $this->hintList = $hintList;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function enterNode(Node $node): ?int
     {
         if ($node instanceof Const_) {

--- a/src/Visitor/HintVisitor.php
+++ b/src/Visitor/HintVisitor.php
@@ -34,7 +34,7 @@ class HintVisitor extends NodeVisitorAbstract
     /**
      * @inheritdoc
      */
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): ?int
     {
         if ($node instanceof Const_) {
             if (false === $node->value instanceof Scalar) {

--- a/src/Visitor/ParentConnectorVisitor.php
+++ b/src/Visitor/ParentConnectorVisitor.php
@@ -15,7 +15,7 @@ class ParentConnectorVisitor extends NodeVisitorAbstract
     /**
      * @inheritdoc
      */
-    public function beforeTraverse(array $nodes)
+    public function beforeTraverse(array $nodes): void
     {
         $this->stack = [];
     }
@@ -23,7 +23,7 @@ class ParentConnectorVisitor extends NodeVisitorAbstract
     /**
      * @inheritdoc
      */
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): void
     {
         if (false === empty($this->stack)) {
             $node->setAttribute('parent', $this->stack[count($this->stack) - 1]);
@@ -34,7 +34,7 @@ class ParentConnectorVisitor extends NodeVisitorAbstract
     /**
      * @inheritdoc
      */
-    public function leaveNode(Node $node)
+    public function leaveNode(Node $node): void
     {
         array_pop($this->stack);
     }

--- a/src/Visitor/ParentConnectorVisitor.php
+++ b/src/Visitor/ParentConnectorVisitor.php
@@ -12,17 +12,11 @@ class ParentConnectorVisitor extends NodeVisitorAbstract
      */
     private $stack;
 
-    /**
-     * @inheritdoc
-     */
     public function beforeTraverse(array $nodes): void
     {
         $this->stack = [];
     }
 
-    /**
-     * @inheritdoc
-     */
     public function enterNode(Node $node): void
     {
         if (false === empty($this->stack)) {
@@ -31,9 +25,6 @@ class ParentConnectorVisitor extends NodeVisitorAbstract
         $this->stack[] = $node;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function leaveNode(Node $node): void
     {
         array_pop($this->stack);

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -5,6 +5,8 @@ namespace Povils\PHPMND\Tests\Console;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Povils\PHPMND\Console\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Class CommandTest
@@ -67,7 +69,7 @@ class CommandTest extends TestCase
      */
     protected function createInput($extensions = '', $suffix = 'php', $exitOnViolation = false, $hint = false)
     {
-        $input = $this->createMock('Symfony\Component\Console\Input\InputInterface');
+        $input = $this->createMock(InputInterface::class);
         $input
             ->method('getOption')
             ->will(
@@ -101,6 +103,6 @@ class CommandTest extends TestCase
      */
     protected function createOutput()
     {
-        return $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+        return $this->createMock(OutputInterface::class);
     }
 }

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -2,8 +2,8 @@
 
 namespace Povils\PHPMND\Tests\Console;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Povils\PHPMND\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CommandTest extends TestCase
 {
 
-    public function testExecuteNoFilesFound()
+    public function testExecuteNoFilesFound(): void
     {
         $input = $this->createInput(null, 'bad_suffix');
         $output = $this->createOutput();
@@ -24,7 +24,7 @@ class CommandTest extends TestCase
         $this->assertSame(Command::EXIT_CODE_SUCCESS, $this->execute([$input, $output]));
     }
 
-    public function testExecuteWithViolationOption()
+    public function testExecuteWithViolationOption(): void
     {
         $input = $this->createInput(null, null, true);
         $output = $this->createOutput();
@@ -32,7 +32,7 @@ class CommandTest extends TestCase
         $this->assertSame(Command::EXIT_CODE_FAILURE, $this->execute([$input, $output]));
     }
 
-    public function testExecuteWithHintOption()
+    public function testExecuteWithHintOption(): void
     {
         $input = $this->createInput('assign', null, true, true);
         $output = $this->createOutput();
@@ -44,12 +44,7 @@ class CommandTest extends TestCase
         $this->execute([$input, $output]);
     }
 
-    /**
-     * @param array $args
-     *
-     * @return int
-     */
-    private function execute(array $args)
+    private function execute(array $args): int
     {
         $command = new Command;
         $class = new \ReflectionClass(new Command);
@@ -59,16 +54,12 @@ class CommandTest extends TestCase
         return $method->invokeArgs($command, $args);
     }
 
-    /**
-     * @param string $extensions
-     * @param string $suffix
-     * @param bool   $exitOnViolation
-     * @param bool   $hint
-     *
-     * @return PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function createInput($extensions = '', $suffix = 'php', $exitOnViolation = false, $hint = false)
-    {
+    protected function createInput(
+        ?string $extensions = '',
+        ?string $suffix = 'php',
+        bool $exitOnViolation = false,
+        bool $hint = false
+    ): MockObject {
         $input = $this->createMock(InputInterface::class);
         $input
             ->method('getOption')
@@ -98,10 +89,7 @@ class CommandTest extends TestCase
         return $input;
     }
 
-    /**
-     * @return PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function createOutput()
+    protected function createOutput(): MockObject
     {
         return $this->createMock(OutputInterface::class);
     }

--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -24,7 +24,7 @@ use Povils\PHPMND\HintList;
  */
 class DetectorTest extends TestCase
 {
-    public function testDetectDefault()
+    public function testDetectDefault(): void
     {
         $detector = $this->createDetector($this->createOption());
         $fileReport = $detector->detect(FileReportTest::getTestFile('test_1'));
@@ -64,7 +64,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    public function testDetectWithAssignExtension()
+    public function testDetectWithAssignExtension(): void
     {
         $option = $this->createOption([new AssignExtension()]);
         $option->setIncludeNumericStrings(true);
@@ -80,7 +80,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    public function testDetectWithPropertyExtension()
+    public function testDetectWithPropertyExtension(): void
     {
         $option = $this->createOption([new PropertyExtension()]);
         $detector = $this->createDetector($option);
@@ -95,7 +95,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    public function testDetectWithArrayExtension()
+    public function testDetectWithArrayExtension(): void
     {
         $option = $this->createOption([new ArrayExtension()]);
         $detector = $this->createDetector($option);
@@ -110,7 +110,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    public function testDetectWithArgumentExtension()
+    public function testDetectWithArgumentExtension(): void
     {
         $option = $this->createOption([new ArgumentExtension()]);
         $detector = $this->createDetector($option);
@@ -126,7 +126,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    public function testDetectWithDefaultParameterExtension()
+    public function testDetectWithDefaultParameterExtension(): void
     {
         $option = $this->createOption([new DefaultParameterExtension()]);
         $detector = $this->createDetector($option);
@@ -142,7 +142,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    public function testDetectWithOperationExtension()
+    public function testDetectWithOperationExtension(): void
     {
         $option = $this->createOption([new OperationExtension()]);
         $detector = $this->createDetector($option);
@@ -166,7 +166,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    public function testDetectWithIgnoreNumber()
+    public function testDetectWithIgnoreNumber(): void
     {
         $ignoreNumbers = [2, 10];
         $option = $this->createOption();
@@ -180,7 +180,7 @@ class DetectorTest extends TestCase
         }
     }
 
-    public function testDetectWithIgnoreFuncs()
+    public function testDetectWithIgnoreFuncs(): void
     {
         $ignoreFuncs = ['round'];
         $option = $this->createOption([new ArgumentExtension()]);
@@ -198,7 +198,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    public function testDetectIncludeStrings()
+    public function testDetectIncludeStrings(): void
     {
         $option = $this->createOption();
         $option->setIncludeStrings(true);
@@ -215,7 +215,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    public function testDetectIncludeStringsAndIgnoreString()
+    public function testDetectIncludeStringsAndIgnoreString(): void
     {
         $option = $this->createOption();
         $option->setIncludeStrings(true);
@@ -233,7 +233,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    public function testDetectWithHint()
+    public function testDetectWithHint(): void
     {
         $option = $this->createOption();
         $option->setExtensions([new AssignExtension]);
@@ -247,7 +247,7 @@ class DetectorTest extends TestCase
         $this->assertSame(['TEST_1::TEST_1'], $hintList->getHintsByValue(3));
     }
 
-    public function testDontDetect0And1WithIncludeNumericStrings()
+    public function testDontDetect0And1WithIncludeNumericStrings(): void
     {
         $option = $this->createOption();
         $option->setExtensions([new AssignExtension]);
@@ -259,7 +259,7 @@ class DetectorTest extends TestCase
         $this->assertEmpty($fileReport->getEntries());
     }
 
-    public function testAllowArrayMappingWithArrayExtension()
+    public function testAllowArrayMappingWithArrayExtension(): void
     {
         $option = $this->createOption();
         $option->setExtensions([new ArrayExtension()]);
@@ -302,12 +302,7 @@ class DetectorTest extends TestCase
         );
     }
 
-    /**
-     * @param Extension[] $extensions
-     *
-     * @return Option
-     */
-    private function createOption(array $extensions = [])
+    private function createOption(array $extensions = []): Option
     {
         $option = new Option;
         $option->setExtensions(
@@ -324,13 +319,7 @@ class DetectorTest extends TestCase
         return $option;
     }
 
-    /**
-     * @param Option $option
-     * @param HintList|null $hintList
-     *
-     * @return Detector
-     */
-    private function createDetector(Option $option, HintList $hintList = null)
+    private function createDetector(Option $option, ?HintList $hintList = null): Detector
     {
         if (null === $hintList) {
             $hintList = new HintList;

--- a/tests/ExtensionResolverTest.php
+++ b/tests/ExtensionResolverTest.php
@@ -14,7 +14,7 @@ use Povils\PHPMND\ExtensionResolver;
  */
 class ExtensionResolverTest extends TestCase
 {
-    public function testResolveDefault()
+    public function testResolveDefault(): void
     {
         $resolver = $this->createResolver();
         $extensions = $resolver->resolve([]);
@@ -22,7 +22,7 @@ class ExtensionResolverTest extends TestCase
         $this->assertSame($resolver->defaults(), $extensions);
     }
 
-    public function testResolveAddExtension()
+    public function testResolveAddExtension(): void
     {
         $resolver = $this->createResolver();
         $extensions = $resolver->resolve(['assign']);
@@ -37,7 +37,7 @@ class ExtensionResolverTest extends TestCase
         $this->assertTrue(false);
     }
 
-    public function testResolveAll()
+    public function testResolveAll(): void
     {
         $resolver = $this->createResolver();
         $extensions = $resolver->resolve(['all']);
@@ -45,7 +45,7 @@ class ExtensionResolverTest extends TestCase
         $this->assertSame($resolver->all(), $extensions);
     }
 
-    public function testResolveWithMinus()
+    public function testResolveWithMinus(): void
     {
         $resolver = $this->createResolver();
         $extensions = $resolver->resolve(['-return']);
@@ -59,7 +59,7 @@ class ExtensionResolverTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function testResolveNotExistingExtension()
+    public function testResolveNotExistingExtension(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -67,10 +67,7 @@ class ExtensionResolverTest extends TestCase
         $resolver->resolve(['not_existing']);
     }
 
-    /**
-     * @return ExtensionResolver
-     */
-    private function createResolver()
+    private function createResolver(): ExtensionResolver
     {
         return new ExtensionResolver();
     }

--- a/tests/FileReportListTest.php
+++ b/tests/FileReportListTest.php
@@ -14,7 +14,7 @@ use Povils\PHPMND\FileReportList;
  */
 class FileReportListTest extends TestCase
 {
-    public function testAddFileReport()
+    public function testAddFileReport(): void
     {
         $fileReportList = new FileReportList;
         /** @var FileReport|Mock $fileReport */
@@ -29,7 +29,7 @@ class FileReportListTest extends TestCase
         $this->assertTrue($fileReportList->hasMagicNumbers());
     }
 
-    public function testDosntHaveMagicNumbers()
+    public function testDoesNotHaveMagicNumbers(): void
     {
         $fileReportList = new FileReportList;
 

--- a/tests/FileReportTest.php
+++ b/tests/FileReportTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FileReportTest extends TestCase
 {
-    public function testFileReport()
+    public function testFileReport(): void
     {
         $file = self::getTestFile('test_1');
         $fileReport = new FileReport($file);
@@ -33,12 +33,7 @@ class FileReportTest extends TestCase
         $this->assertTrue($fileReport->hasMagicNumbers());
     }
 
-    /**
-     * @param string $name
-     *
-     * @return SplFileInfo
-     */
-    public static function getTestFile($name)
+    public static function getTestFile(string $name): SplFileInfo
     {
         return new SplFileInfo(
             __DIR__ . DIRECTORY_SEPARATOR . 'files' . DIRECTORY_SEPARATOR . "$name.php",


### PR DESCRIPTION
Since version 2 bumps the PHP version up to 7.1 we can start using newer features like type hints and we can get rid of some of the dependencies in the composer json file.

All the tests pass with the changes 

```
PHPUnit 7.3.5 by Sebastian Bergmann and contributors.

.........................                                         25 / 25 (100%)

Time: 1.66 seconds, Memory: 20.00MB

OK (25 tests, 36 assertions)

```