### PR TITLE
Add default ignore functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,38 +87,37 @@ $ phpmnd wordpress --ignore-numbers=2,-1 --ignore-funcs=round,sleep --exclude=te
 --extensions=default_parameter,-return,argument
 ```
 
-The ``--ignore-numbers`` option will exclude a list of comma separated numbers from the code analysis.
-
-The ``--ignore-funcs`` option will exclude a list of comma separated functions from the code analysis, when using the "argument" extension.
-
-The ``--exclude`` option will exclude a directory, which must be relative to the source, from the code analysis. Multiple values are allowed (e.g. --exclude=tests --exclude=examples).
-
-The ``--exclude-path`` option will exclude a path, which must be relative to the source, from the code analysis. Multiple values are allowed.
+The ``--allow-array-mapping`` option allow keys as strings when using "array" extension.
 
 The ``--exclude-file`` option will exclude a file from the code analysis. Multiple values are allowed.
 
-The ``--suffixes`` option will configure a comma separated list of valid source code filename extensions.
+The ``--exclude-path`` option will exclude a path, which must be relative to the source, from the code analysis. Multiple values are allowed.
 
-The ``--progress`` option will display a progress bar.
-
-The ``--hint`` option will suggest replacements for magic numbers based on your codebase constants.
-
-The ``--non-zero-exit-on-violation`` option will return a non zero exit code, when there are any magic numbers in your codebase.
-
-The ``--strings`` option will include strings literal search in code analysis.
-
-The ``--ignore-strings`` option will exclude strings from the code analysis, when using the "strings" option.
+The ``--exclude`` option will exclude a directory, which must be relative to the source, from the code analysis. Multiple values are allowed (e.g. --exclude=tests --exclude=examples).
 
 The ``--extensions`` option lets you extend the code analysis. The provided extensions must be comma separated.
 
+The ``--hint`` option will suggest replacements for magic numbers based on your codebase constants.
+
+The ``--ignore-funcs`` option will exclude a list of comma separated functions from the code analysis, when using the "argument" extension. Defaults to `intval`, `floatval`, `strval`.
+
+The ``--ignore-numbers`` option will exclude a list of comma separated numbers from the code analysis.
+
+The ``--ignore-strings`` option will exclude strings from the code analysis, when using the "strings" option.
+
 The ``--include-numeric-string`` option forces numeric strings such as "1234" to also be treated as a number.
 
-The ``--allow-array-mapping`` option allow keys as strings when using "array" extension.
+The ``--non-zero-exit-on-violation`` option will return a non zero exit code, when there are any magic numbers in your codebase.
 
-The ``--xml-output`` option will generate an report in an Xml format to the path specified by the option.
+The ``--progress`` option will display a progress bar.
+
+The ``--strings`` option will include strings literal search in code analysis.
+
+The ``--suffixes`` option will configure a comma separated list of valid source code filename extensions.
 
 The ``--whitelist`` option will only process the files listed in the file specified. This is useful for incremental anaysis.
 
+The ``--xml-output`` option will generate an report in an Xml format to the path specified by the option.
 **By default it analyses conditions, return statements, and switch cases.**
 
 Choose from the list of available extensions:
@@ -163,6 +162,22 @@ case 3;
 To include all extensions.
 
 If extensions start with a minus, it means that these will be removed from the code analysis. I would recommend to clean up your code by using the default extension before using any of these extensions.
+
+## Ignoring a number from analysis
+
+Sometimes magic numbers are required. For example implementing a known mathematical formula, by default `intval`, `floatval` and `strval` mark a number as not magic.
+
+eg
+
+```
+$percent  = $number / 100;
+```
+would show 100 sa a magic number
+
+```
+$percent = $number / intval(100);
+```
+would mark 100 as not magic.
 
 ## Contributing
 

--- a/src/Console/Option.php
+++ b/src/Console/Option.php
@@ -22,7 +22,11 @@ class Option
     /**
      * @var array
      */
-    private $ignoreFuncs = [];
+    private $ignoreFuncs = [
+        'intval',
+        'floatval',
+        'strval',
+    ];
 
     /**
      * @var array

--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -302,6 +302,42 @@ class DetectorTest extends TestCase
         );
     }
 
+    public function testDefaultIgnoreFunctions(): void
+    {
+        $option = $this->createOption();
+        $option->setExtensions([new ArrayExtension()]);
+        $option->setIncludeNumericStrings(true);
+        $detector = $this->createDetector($option);
+
+        $fileReport = $detector->detect(FileReportTest::getTestFile('test_1'));
+
+        $results = $fileReport->getEntries();
+
+        $this->assertNotContains(
+            [
+                'line' => 56,
+                'value' => 13,
+            ],
+            $results
+        );
+
+        $this->assertNotContains(
+            [
+                'line' => 57,
+                'value' => 3.14,
+            ],
+            $results
+        );
+
+        $this->assertNotContains(
+            [
+                'line' => 58,
+                'value' => 10,
+            ],
+            $results
+        );
+    }
+
     private function createOption(array $extensions = []): Option
     {
         $option = new Option;

--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -270,7 +270,7 @@ class DetectorTest extends TestCase
 
         $this->assertContains(
             [
-                'line' => 55,
+                'line' => 64,
                 'value' => 1234,
             ],
             $fileReport->getEntries()

--- a/tests/files/test_1.php
+++ b/tests/files/test_1.php
@@ -49,4 +49,13 @@ class TEST_1
    public function returnNegative() {
       return -2;
    }
+
+   public function ignoreValues()
+   {
+       return [
+           intval(100),
+           floatval(3.14),
+           strval('10')
+       ];
+   }
 }

--- a/tests/files/test_1.php
+++ b/tests/files/test_1.php
@@ -60,7 +60,7 @@ class TEST_1
    }
   
    public function returnFromKey() {
-    $a = [];
-    return $a[1234];
+        $a = [];
+        return $a[1234];
    }
 }


### PR DESCRIPTION
As a default, intval, strval and floatval will class numbers as not
magic.

This is an easy and clean way to ignore functions while keeping
readability and perfomance of code.

Fixes #82