### PR TITLE
Allow multiple files and/or directories

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -245,7 +245,7 @@ class Command extends BaseCommand
     protected function createFinder(InputInterface $input): PHPFinder
     {
         return new PHPFinder(
-            $input->getArgument('directories') ?:[''],
+            $input->getArgument('directories'),
             $input->getOption('exclude'),
             $input->getOption('exclude-path'),
             $input->getOption('exclude-file'),

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -33,9 +33,9 @@ class Command extends BaseCommand
             ->setDefinition(
                 [
                     new InputArgument(
-                        'directory',
+                        'directories',
                         InputArgument::REQUIRED + InputArgument::IS_ARRAY,
-                        'Directory to analyze'
+                        'One or more files and/or directories to analyze'
                     )
                 ]
             )
@@ -245,7 +245,7 @@ class Command extends BaseCommand
     protected function createFinder(InputInterface $input): PHPFinder
     {
         return new PHPFinder(
-            $input->getArgument('directory'),
+            $input->getArgument('directories') ?:[''],
             $input->getOption('exclude'),
             $input->getOption('exclude-path'),
             $input->getOption('exclude-file'),

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -34,7 +34,7 @@ class Command extends BaseCommand
                 [
                     new InputArgument(
                         'directory',
-                        InputArgument::REQUIRED,
+                        InputArgument::REQUIRED + InputArgument::IS_ARRAY,
                         'Directory to analyze'
                     )
                 ]

--- a/src/PHPFinder.php
+++ b/src/PHPFinder.php
@@ -3,6 +3,7 @@
 namespace Povils\PHPMND;
 
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Class Finder
@@ -19,13 +20,23 @@ class PHPFinder extends Finder
         array $suffixes
     ) {
         parent::__construct();
+        $dirs = array_filter($directories, 'is_dir');
+        $files = array_diff($directories, $dirs);
 
         $this
             ->files()
-            ->in($directories)
+            ->in($dirs)
             ->exclude(array_merge(['vendor'], $exclude))
             ->ignoreDotFiles(true)
-            ->ignoreVCS(true);
+            ->ignoreVCS(true)
+            ->append(
+                array_map(
+                    function (string $file) {
+                        return new SplFileInfo(realpath($file), dirname($file), $file);
+                    },
+                    $files
+                )
+            );
 
         foreach ($suffixes as $suffix) {
             $this->name('*.' . $suffix);

--- a/src/PHPFinder.php
+++ b/src/PHPFinder.php
@@ -12,16 +12,17 @@ use Symfony\Component\Finder\Finder;
 class PHPFinder extends Finder
 {
     public function __construct(
-        string $directory,
+        array $directories,
         array $exclude,
         array $excludePaths,
         array $excludeFiles,
         array $suffixes
     ) {
         parent::__construct();
+
         $this
             ->files()
-            ->in($directory)
+            ->in($directories)
             ->exclude(array_merge(['vendor'], $exclude))
             ->ignoreDotFiles(true)
             ->ignoreVCS(true);

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -82,7 +82,7 @@ class CommandTest extends TestCase
             ->will(
                 $this->returnValueMap(
                     [
-                        ['directory', ['tests/files']],
+                        ['directories', ['tests/files']],
                     ]
                 )
             );

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -82,7 +82,7 @@ class CommandTest extends TestCase
             ->will(
                 $this->returnValueMap(
                     [
-                        ['directory', 'tests/files'],
+                        ['directory', ['tests/files']],
                     ]
                 )
             );


### PR DESCRIPTION
This allows ` ./bin/phpmnd src/Console src/Extension tests` without affecting  the old command ` ./bin/phpmnd src`

My end goal is allowing folders/filenames interchangeably, so that pre-commit hooks can run on changed files only, but I'd like this to be accepted as first step.