### PR TITLE
Update the composer version to PHP7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ git:
 
 matrix:
   include:
-    - php: 7.1
     - php: 7.2
       env: LINT=true
     - php: 7.2
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
       env: COMPOSER_FLAGS="--prefer-lowest"
 
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.4
-      env: COMPOSER_FLAGS="--prefer-lowest"
 
   fast_finish: true
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "issues": "https://github.com/povils/phpmnd/issues"
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "symfony/console": "^4.0",
     "symfony/finder": "^4.0",
     "nikic/php-parser": "^4.0",
@@ -21,7 +21,7 @@
     "phpunit/php-timer": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^8.0",
     "squizlabs/php_codesniffer": "^2.8.1"
   },
   "autoload": {


### PR DESCRIPTION
This change will update the composer version to php7.2 and update phpunit to v8

Support for 7.1 has ended so we should upgrade to 7.2 - Security support for 7.2 will end in Nov 2020