### PR TITLE
Update to php 7.3 and update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
       env: LINT=true
     - php: 7.2
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.3
+      env: LINT=true
+    - php: 7.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
       env: LINT=true
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+      env: LINT=true
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
   fast_finish: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v2.3.0] - 2020-04-15
+- Support PHP 7.3
+- Update dependencies
+
 ## [v2.2.0] - 2019-01-12
 - Add default ignore functions (intval, strval and floatval)
 - Fix negative number whitelisting
 - Ignore the negative value if the scalar does not have a value field
 - Allow multiple files and directories
--
+
 ## [v2.1.0] - 2019-01-27
 - Check magic numbers in constant arrays.
 - Catch array[magic_number]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v2.3.0] - 2020-04-15
-- Support PHP 7.3
+- Support PHP 7.3 and PHP 7.4
 - Update dependencies
 
 ## [v2.2.0] - 2019-01-12

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ clone_folder: c:\projects\workspace
 environment:
   matrix:
   - dependencies: highest
+    php_ver_target: 7.4
+  - dependencies: highest
     php_ver_target: 7.3
   - dependencies: highest
     php_ver_target: 7.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ clone_folder: c:\projects\workspace
 environment:
   matrix:
   - dependencies: highest
+    php_ver_target: 7.3
+  - dependencies: highest
     php_ver_target: 7.2
   - dependencies: highest
     php_ver_target: 7.1

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
   },
   "require": {
     "php": "^7.1",
-    "symfony/console": "^4.0",
-    "symfony/finder": "^4.0",
+    "symfony/console": "^4.0||^5.0",
+    "symfony/finder": "^4.0||^5.0",
     "nikic/php-parser": "^4.0",
-    "jakub-onderka/php-console-highlighter": "^0.4",
-    "phpunit/php-timer": "^2.0"
+    "php-parallel-lint/php-console-highlighter": "^0.4",
+    "phpunit/php-timer": "^2.0||^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
-    "squizlabs/php_codesniffer": "^2.8.1"
+    "phpunit/phpunit": "^7.0||^8.0||^9.0",
+    "squizlabs/php_codesniffer": "^2.8.1||^3.5"
   },
   "autoload": {
     "psr-4": {
@@ -42,7 +42,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "2.1-dev"
+      "dev-master": "2.3-dev"
     }
   }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Application extends BaseApplication
 {
-    const VERSION = '2.2.0';
+    const VERSION = '2.3.0';
     const COMMAND_NAME = 'phpmnd';
 
     public function __construct()


### PR DESCRIPTION
I'm a great fan of this tool. However, when trying to install alongside other tools such as phpunit version 9, phpmnd cannot be installed because it needs `phpunit/php-timer:2.0`. Phpunit nowadays uses `phpunit/php-timer:3.0`.
I upgraded to php7.3 as well because new version of used tools have this as a requirement (phpunit v9 and php-timer v3 for example).

Since this is a backwards incompatible change, a new major version should be released for this.
Tests and codestyle are still good.

Please provide feedback if I have missed anything or did something wrong. 
I did not see any issues (specifically) for this, so I decided to work on this myself. Please let me know if I overlooked.