### PR TITLE
Make file:line selectable

### DIFF
--- a/src/Printer/Console.php
+++ b/src/Printer/Console.php
@@ -29,7 +29,7 @@ class Console implements Printer
             $total += count($entries);
             foreach ($entries as $entry) {
                 $output->writeln(sprintf(
-                    '%s:%d. Magic number: %s',
+                    '%s:%d  Magic number: %s',
                     $fileReport->getFile()->getRelativePathname(),
                     $entry['line'],
                     $entry['value']


### PR DESCRIPTION
When double-clicking file:line the trailing dot also gets selected thus the clipboard cannot be used to paste into the command line: `editor file:line.`

![kép](https://user-images.githubusercontent.com/952007/92872892-c75d8f00-f406-11ea-9abe-916596bbe955.png)
