### PR TITLE
Update to allow installing with up coming php 8.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
       env: LINT=true
     - php: 7.4
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 8.0
+      env: LINT=true
+    - php: 8.0
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 #    - php: 8.0
 #      env: LINT=true
   allow_failures:
-      -  php: nightly
+      - php: nightly
         env: LINT=true
 
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ matrix:
       env: LINT=true
     - php: 7.4
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 8.0snapshot
-      env: LINT=true
-    - php: 8.0snapshot
-      env: COMPOSER_FLAGS="--prefer-lowest"
+#    - php:
+#      env: LINT=true
+#    - php: 8.0
+#      env: COMPOSER_FLAGS="--prefer-lowest"
 
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
       env: LINT=true
     - php: 7.4
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 8.0
+    - php: 8.0snapshot
       env: LINT=true
-    - php: 8.0
+    - php: 8.0snapshot
       env: COMPOSER_FLAGS="--prefer-lowest"
 
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
       env: LINT=true
 #    - php: 8.0
 #      env: LINT=true
+  allow_failures:
+      -  php: nightly
+        env: LINT=true
 
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,8 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.4
       env: LINT=true
-    - php: 7.4
-      env: COMPOSER_FLAGS="--prefer-lowest"
-#    - php:
-#      env: LINT=true
 #    - php: 8.0
-#      env: COMPOSER_FLAGS="--prefer-lowest"
+#      env: LINT=true
 
   fast_finish: true
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "phpunit/php-timer": "^2.0||^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0||^9.0",
+    "phpunit/phpunit": "^7.0||^8.0||^9.0",
     "squizlabs/php_codesniffer": "^2.8.1||^3.5"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,48 +1,50 @@
 {
-  "name": "povils/phpmnd",
-  "type": "application",
-  "description": "A tool to detect Magic numbers in codebase",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Povilas Susinskas",
-      "email": "povilassusinskas@gmail.com"
+    "name": "povils/phpmnd",
+    "type": "application",
+    "description": "A tool to detect Magic numbers in codebase",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Povilas Susinskas",
+            "email": "povilassusinskas@gmail.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/povils/phpmnd/issues"
+    },
+    "require": {
+        "php": "^7.1|^8.0",
+        "symfony/console": "^4.0||^5.0",
+        "symfony/finder": "^4.0||^5.0",
+        "nikic/php-parser": "^4.0",
+        "php-parallel-lint/php-console-highlighter": "^0.4",
+        "phpunit/php-timer": "^2.0||^3.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.0||^8.0||^9.0",
+        "squizlabs/php_codesniffer": "^2.8.1||^3.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Povils\\PHPMND\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Povils\\PHPMND\\Tests\\": "tests/"
+        }
+    },
+    "bin": [
+        "bin/phpmnd"
+    ],
+    "scripts": {
+        "test": "phpunit",
+        "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/files",
+        "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/files"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.3-dev"
+        }
     }
-  ],
-  "support": {
-    "issues": "https://github.com/povils/phpmnd/issues"
-  },
-  "require": {
-    "php": "^7.1|^8.0",
-    "symfony/console": "^4.0||^5.0",
-    "symfony/finder": "^4.0||^5.0",
-    "nikic/php-parser": "^4.0",
-    "php-parallel-lint/php-console-highlighter": "^0.4",
-    "phpunit/php-timer": "^2.0||^3.0"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^7.0||^8.0||^9.0",
-    "squizlabs/php_codesniffer": "^2.8.1||^3.5"
-  },
-  "autoload": {
-    "psr-4": {
-      "Povils\\PHPMND\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Povils\\PHPMND\\Tests\\": "tests/"
-    }
-  },
-  "bin": ["bin/phpmnd"],
-  "scripts": {
-    "test": "phpunit",
-    "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/files",
-    "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/files"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "2.3-dev"
-    }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "issues": "https://github.com/povils/phpmnd/issues"
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.1|^8.0",
     "symfony/console": "^4.0||^5.0",
     "symfony/finder": "^4.0||^5.0",
     "nikic/php-parser": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "phpunit/php-timer": "^2.0||^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0||^8.0||^9.0",
+    "phpunit/phpunit": "^8.0||^9.0",
     "squizlabs/php_codesniffer": "^2.8.1||^3.5"
   },
   "autoload": {


### PR DESCRIPTION
Hi

I'm getting ahead of getting ready to test with PHP 8.0.

So this is one of the packages that broke for me.

I've set it, composer, to also support PHP 8.0.

Unfortunately, it doesn't look like Travis as support for 8.0 testing yet or I couldn't work out the magic string.

I have put the rules in uncommented.

I've also removed the 7.4 --prefer-lowest check as PHPUnit 7 breaks with PHP 7.4.