### PR TITLE
Phar distribution improvement

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -1,5 +1,4 @@
 {
-    "chmod": "0755",
     "directories": [
         "src"
     ],
@@ -48,9 +47,7 @@
         }
     ],
     "git-version": "package_version",
-    "main": "bin/phpmnd",
     "output": "build/phpmnd.phar",
-    "stub": true,
-    "compactors": "Herrera\\Box\\Compactor\\Php",
+    "compactors": "KevinGH\\Box\\Compactor\\Php",
     "compression": "GZ"
 }


### PR DESCRIPTION
Very few changes on `box` compile action.

Removed 4 recommandations as specified by box itself (version 3.13.0@275b091 2021-05-15 19:13:46 UTC)

```
💡  4 recommendations found:
    - The "main" setting can be omitted since is set to its default value
    - The "stub" setting can be omitted since is set to its default value
    - The compactor "Herrera\Box\Compactor\Php" has been deprecated, use "KevinGH\Box\Compactor\Php" instead.
    - The "chmod" setting can be omitted since is set to its default value
```