### PR TITLE
maintenance .gitignore & .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,13 @@
 * text=auto eol=lf
 
 # Do not include the following files when creating repo artifacts, e.g. the zip
-.editorconfig export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
-CHANGELOG.md export-ignore
-CONTRIBUTING.md export-ignore
-LICENSE export-ignore
-phpunit.xml.dist export-ignore
-README.md export-ignore
-tests/ export-ignore
-box.json.dist export-ignore
-build/ export-ignore
+/.* export-ignore
+/tests/ export-ignore
+/build/ export-ignore
+/box.json.dist export-ignore
+/CHANGELOG.md export-ignore
+/CONTRIBUTING.md export-ignore
+/LICENSE export-ignore
+/phpunit.xml.dist export-ignore
+/README.md export-ignore
+/demo.gif export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,5 +8,3 @@
 /CHANGELOG.md export-ignore
 /CONTRIBUTING.md export-ignore
 /phpunit.xml.dist export-ignore
-/README.md export-ignore
-/demo.gif export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@
 /box.json.dist export-ignore
 /CHANGELOG.md export-ignore
 /CONTRIBUTING.md export-ignore
-/LICENSE export-ignore
 /phpunit.xml.dist export-ignore
 /README.md export-ignore
 /demo.gif export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,8 @@
 
 # Do not include the following files when creating repo artifacts, e.g. the zip
 /.* export-ignore
-/tests/ export-ignore
 /build/ export-ignore
+/tests/ export-ignore
 /box.json.dist export-ignore
 /CHANGELOG.md export-ignore
 /CONTRIBUTING.md export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-composer.lock
-vendor
-.idea
-build
+/.idea
+/build
+/vendor
+/.phpunit.result.cache
+/composer.lock


### PR DESCRIPTION
sorted Directory first, and alphabetical order.

and,
### .gitattributes
* remove `LICENSE export-ignore` and `/README.md export-ignore`
   * should not be removed under distribution. 
   * see https://github.com/povils/phpmnd/pull/138#discussion_r715981652
* Add `/.* export-ignore`
   * to ignore `.github` directories & other dot files.  

### .gitignore
* Add `/.phpunit.result.cache`