### PR TITLE
Drop php <7.4 support, symfony <4.4, add php 8.1 to pipeline

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4']
+        php-version: ['8.0']
 
     name: Autoreview on PHP ${{ matrix.php-version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,21 +18,13 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php-version: ['7.4', '8.0', '8.1']
         symfony-require: ['^4', '^5', '^6']
         exclude:
-          - symfony-require: "^5"
-            php-version: "7.1"
-          - symfony-require: "^6"
-            php-version: "7.1"
-          - symfony-require: "^6"
-            php-version: "7.2"
-          - symfony-require: "^6"
-            php-version: "7.3"
           - symfony-require: "^6"
             php-version: "7.4"
         include:
-          - { operating-system: 'windows-latest', php-version: '7.4', symfony-require: '^5' }
+          - { operating-system: 'windows-latest', php-version: '8.0', symfony-require: '^5' }
 
     name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, with Symfony ${{ matrix.symfony-require }}
 

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -44,8 +44,9 @@ jobs:
             composer-${{ runner.os }}-${{ matrix.php-version }}-
             composer-${{ runner.os }}-
             composer-
+
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
 
-      - name: Run ${{ matrix.check }}
+      - name: Run Code Style Checker
         run: composer run cs-check

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PHP Magic Number Detector (PHPMND)
 
-[![Minimum PHP version: 7.1.0](https://img.shields.io/badge/php-7.1.0%2B-blue.svg)](https://packagist.org/packages/povils/phpmnd)
+[![Minimum PHP version: 7.4.0](https://img.shields.io/badge/php-7.4.0%2B-blue.svg)](https://packagist.org/packages/povils/phpmnd)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/povils/phpmnd/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/povils/phpmnd/?branch=master)
 [![License](https://poser.pugx.org/povils/phpmnd/license)](https://packagist.org/packages/povils/phpmnd)
 [![CI](https://github.com/povils/phpmnd/workflows/CI/badge.svg?branch=master)](https://github.com/povils/phpmnd)

--- a/bin/phpmnd
+++ b/bin/phpmnd
@@ -10,11 +10,11 @@ if (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) === false) {
     exit(1);
 }
 
-if (\version_compare('7.1.0', \PHP_VERSION, '>')) {
+if (\version_compare('7.4.0', \PHP_VERSION, '>')) {
     \fwrite(
         \STDERR,
         \sprintf(
-            'This version of PHPMND is supported on PHP 7.1.' . \PHP_EOL .
+            'This version of PHPMND is supported on PHP 7.4.' . \PHP_EOL .
             'You are using PHP %s%s.' . \PHP_EOL,
             \PHP_VERSION,
             \defined('PHP_BINARY') ? ' (' . \PHP_BINARY . ')' : ''

--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,5 @@
         "test": "phpunit",
         "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/Fixtures/Files",
         "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=tests/Fixtures/Files"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.5-dev"
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/console": "^4.4 || ^5.0 || ^6.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",
         "nikic/php-parser": "^4.13",
-        "php-parallel-lint/php-console-highlighter": "^0.5",
+        "php-parallel-lint/php-console-highlighter": "^1.0",
         "phpunit/php-timer": "^2.0||^3.0||^4.0||^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
         "issues": "https://github.com/povils/phpmnd/issues"
     },
     "require": {
-        "php": "^7.1|^8.0",
-        "symfony/console": "^4.0||^5.0||^6.0",
-        "symfony/finder": "^4.0||^5.0||^6.0",
-        "nikic/php-parser": "^4.0",
+        "php": "^7.4 || ^8.0",
+        "symfony/console": "^4.4 || ^5.0 || ^6.0",
+        "symfony/finder": "^4.4 || ^5.0 || ^6.0",
+        "nikic/php-parser": "^4.13",
         "php-parallel-lint/php-console-highlighter": "^0.5",
         "phpunit/php-timer": "^2.0||^3.0||^4.0||^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0||^8.0||^9.0",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^2.8.1||^3.5"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,12 @@
          failOnRisky="true"
          verbose="true"
 >
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="PHPMND Test Suite">
             <directory>tests/</directory>
@@ -14,14 +20,4 @@
             <exclude>tests/Fixtures</exclude>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>src/</directory>
-
-            <exclude>
-                <directory>vendor/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -30,10 +30,7 @@ class RunCommand extends BaseCommand
     public const SUCCESS = 0;
     public const FAILURE = 1;
 
-    /**
-     * @var Timer
-     */
-    private $timer;
+    private Timer $timer;
 
     protected function configure(): void
     {

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Povils\PHPMND\Command;
 
-use JakubOnderka\PhpConsoleColor\ConsoleColor;
-use JakubOnderka\PhpConsoleHighlighter\Highlighter;
+use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
+use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
 use Povils\PHPMND\Console\Application;
 use Povils\PHPMND\Console\Option;
 use Povils\PHPMND\Detector;

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -17,10 +17,7 @@ class Application extends BaseApplication
     public const VERSION = '2.5.0';
     private const NAME = 'phpmnd';
 
-    /**
-     * @var Container
-     */
-    private $container;
+    private Container $container;
 
     public function __construct(Container $container)
     {

--- a/src/Console/Option.php
+++ b/src/Console/Option.php
@@ -11,17 +11,17 @@ class Option
     /**
      * @var Extension[]
      */
-    private $extensions = [];
+    private array $extensions = [];
 
     /**
      * @var array
      */
-    private $ignoreNumbers = [0, 0., 1];
+    private array $ignoreNumbers = [0, 0., 1];
 
     /**
      * @var array
      */
-    private $ignoreFuncs = [
+    private array $ignoreFuncs = [
         'intval',
         'floatval',
         'strval',
@@ -30,27 +30,15 @@ class Option
     /**
      * @var array
      */
-    private $ignoreStrings = ['', '0', '1'];
+    private array $ignoreStrings = ['', '0', '1'];
 
-    /**
-     * @var bool
-     */
-    private $includeStrings = false;
+    private bool $includeStrings = false;
 
-    /**
-     * @var bool
-     */
-    private $giveHint = false;
+    private bool $giveHint = false;
 
-    /**
-     * @var bool
-     */
-    private $includeNumericStrings = false;
+    private bool $includeNumericStrings = false;
 
-    /**
-     * @var bool
-     */
-    private $allowArrayMapping = false;
+    private bool $allowArrayMapping = false;
 
     public function setExtensions(array $extensions): void
     {
@@ -82,12 +70,12 @@ class Option
         return $this->ignoreFuncs;
     }
 
-    public function includeStrings(): ?bool
+    public function includeStrings(): bool
     {
         return $this->includeStrings;
     }
 
-    public function setIncludeStrings(?bool $includeStrings): void
+    public function setIncludeStrings(bool $includeStrings): void
     {
         $this->includeStrings = $includeStrings;
     }
@@ -112,22 +100,22 @@ class Option
         $this->giveHint = $giveHint;
     }
 
-    public function includeNumericStrings(): ?bool
+    public function includeNumericStrings(): bool
     {
         return $this->includeNumericStrings;
     }
 
-    public function setIncludeNumericStrings(?bool $includeNumericStrings): void
+    public function setIncludeNumericStrings(bool $includeNumericStrings): void
     {
         $this->includeNumericStrings = $includeNumericStrings;
     }
 
-    public function allowArrayMapping(): ?bool
+    public function allowArrayMapping(): bool
     {
         return $this->allowArrayMapping;
     }
 
-    public function setAllowArrayMapping(?bool $allowArrayMapping): void
+    public function setAllowArrayMapping(bool $allowArrayMapping): void
     {
         $this->allowArrayMapping = $allowArrayMapping;
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -20,9 +20,9 @@ use function version_compare;
 
 class Container
 {
-    private $keys = [];
-    private $factories = [];
-    private $values = [];
+    private array $keys = [];
+    private array $factories = [];
+    private array $values = [];
 
     private function __construct(array $values)
     {

--- a/src/DetectionResult.php
+++ b/src/DetectionResult.php
@@ -8,15 +8,9 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class DetectionResult
 {
-    /**
-     * @var SplFileInfo
-     */
-    private $file;
+    private SplFileInfo $file;
 
-    /**
-     * @var int
-     */
-    private $line;
+    private int $line;
 
     /**
      * @var float|int|string

--- a/src/Detector.php
+++ b/src/Detector.php
@@ -14,20 +14,11 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class Detector
 {
-    /**
-     * @var Option
-     */
-    private $option;
+    private Option $option;
 
-    /**
-     * @var FileParser
-     */
-    private $parser;
+    private FileParser $parser;
 
-    /**
-     * @var HintList
-     */
-    private $hintList;
+    private HintList $hintList;
 
     public function __construct(FileParser $parser, Option $option, HintList $hintList)
     {

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -9,10 +9,7 @@ use Povils\PHPMND\Console\Option;
 
 abstract class Extension
 {
-    /**
-     * @var Option
-     */
-    protected $option;
+    protected Option $option;
 
     abstract public function extend(Node $node): bool;
 

--- a/src/ExtensionResolver.php
+++ b/src/ExtensionResolver.php
@@ -22,22 +22,22 @@ class ExtensionResolver
     /**
      * @var Extension[]
      */
-    private $allExtensions;
+    private array $allExtensions = [];
 
     /**
      * @var Extension[]
      */
-    private $defaultExtensions;
+    private array $defaultExtensions = [];
 
     /**
      * @var Extension[]
      */
-    private $resolvedExtensions = [];
+    private array $resolvedExtensions = [];
 
     public function resolve(array $extensionNames): array
     {
         $this->resolvedExtensions = $this->defaults();
-        if (($allKey = array_search(self::ALL_EXTENSIONS, $extensionNames)) !== false) {
+        if (($allKey = array_search(self::ALL_EXTENSIONS, $extensionNames, true)) !== false) {
             $this->resolvedExtensions = $this->all();
             unset($extensionNames[$allKey]);
         }
@@ -56,7 +56,7 @@ class ExtensionResolver
 
     public function defaults(): array
     {
-        if (null === $this->defaultExtensions) {
+        if ([] === $this->defaultExtensions) {
             $this->defaultExtensions = [
                 new ConditionExtension,
                 new ReturnExtension,
@@ -69,7 +69,7 @@ class ExtensionResolver
 
     public function all(): array
     {
-        if (null === $this->allExtensions) {
+        if ([] === $this->allExtensions) {
             $this->allExtensions = array_merge(
                 [
                     new ArgumentExtension,
@@ -95,7 +95,7 @@ class ExtensionResolver
 
                     return;
                 }
-            };
+            }
         }
     }
 

--- a/src/FileReportGenerator.php
+++ b/src/FileReportGenerator.php
@@ -17,15 +17,9 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class FileReportGenerator
 {
-    /**
-     * @var SplFileInfo
-     */
-    private $file;
+    private SplFileInfo $file;
 
-    /**
-     * @var Option
-     */
-    private $option;
+    private Option $option;
 
     public function __construct(SplFileInfo $file, Option $option)
     {

--- a/src/HintList.php
+++ b/src/HintList.php
@@ -6,10 +6,7 @@ namespace Povils\PHPMND;
 
 class HintList
 {
-    /**
-     * @var array
-     */
-    private $constants = [];
+    private array $constants = [];
 
     /**
      * @param mixed $magicNumber

--- a/src/PhpParser/FileParser.php
+++ b/src/PhpParser/FileParser.php
@@ -12,10 +12,7 @@ use Throwable;
 
 class FileParser
 {
-    /**
-     * @var Parser
-     */
-    private $parser;
+    private Parser $parser;
 
     public function __construct(Parser $parser)
     {

--- a/src/PhpParser/Visitor/DetectionVisitor.php
+++ b/src/PhpParser/Visitor/DetectionVisitor.php
@@ -6,19 +6,17 @@ namespace Povils\PHPMND\PhpParser\Visitor;
 
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
+use Povils\PHPMND\DetectionResult;
 use Povils\PHPMND\FileReportGenerator;
 
 class DetectionVisitor extends NodeVisitorAbstract
 {
-    /**
-     * @var FileReportGenerator
-     */
-    private $generator;
+    private FileReportGenerator $generator;
 
     /**
      * @var array<iterable<DetectionResult>
      */
-    private $reports = [];
+    private array $reports = [];
 
     public function __construct(FileReportGenerator $generator)
     {

--- a/src/PhpParser/Visitor/HintVisitor.php
+++ b/src/PhpParser/Visitor/HintVisitor.php
@@ -15,10 +15,7 @@ use Povils\PHPMND\HintList;
 
 class HintVisitor extends NodeVisitorAbstract
 {
-    /**
-     * @var HintList
-     */
-    private $hintList;
+    private HintList $hintList;
 
     public function __construct(HintList $hintList)
     {

--- a/src/PhpParser/Visitor/ParentConnectorVisitor.php
+++ b/src/PhpParser/Visitor/ParentConnectorVisitor.php
@@ -12,7 +12,7 @@ class ParentConnectorVisitor extends NodeVisitorAbstract
     /**
      * @var Node[]
      */
-    private $stack;
+    private array $stack;
 
     public function beforeTraverse(array $nodes): void
     {

--- a/src/Printer/Console.php
+++ b/src/Printer/Console.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Povils\PHPMND\Printer;
 
-use JakubOnderka\PhpConsoleHighlighter\Highlighter;
+use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
 use Povils\PHPMND\DetectionResult;
 use Povils\PHPMND\HintList;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Printer/Console.php
+++ b/src/Printer/Console.php
@@ -13,10 +13,7 @@ class Console implements Printer
 {
     private const DEFAULT_LINE_LENGTH = 80;
 
-    /**
-     * @var Highlighter
-     */
-    private $highlighter;
+    private Highlighter $highlighter;
 
     public function __construct(Highlighter $highlighter)
     {

--- a/src/Printer/Xml.php
+++ b/src/Printer/Xml.php
@@ -12,10 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Xml implements Printer
 {
-    /**
-     * @var string
-     */
-    private $outputPath;
+    private string $outputPath;
 
     public function __construct(string $outputPath)
     {

--- a/tests/Command/RunCommandTest.php
+++ b/tests/Command/RunCommandTest.php
@@ -12,10 +12,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class RunCommandTest extends TestCase
 {
-    /**
-     * @var CommandTester
-     */
-    private $commandTester;
+    private CommandTester $commandTester;
 
     protected function setUp(): void
     {
@@ -54,7 +51,7 @@ class RunCommandTest extends TestCase
         ]);
 
         $this->assertSame(RunCommand::FAILURE, $this->commandTester->getStatusCode());
-        $this->assertTrue(strpos($this->commandTester->getDisplay(), 'Suggestions:') !== false);
+        $this->assertStringContainsString('Suggestions:', $this->commandTester->getDisplay());
     }
 
     public function testItDoesNotFailCommandWhenFileOnPathDoesNotExist(): void
@@ -65,14 +62,6 @@ class RunCommandTest extends TestCase
         ]);
 
         $this->assertSame(RunCommand::SUCCESS, $this->commandTester->getStatusCode());
-        $output = $this->commandTester->getDisplay();
-
-        /* This should use assertStringContainsString but the lowest phpunit supported does not allow that */
-        $found = false;
-        if (strpos($output, 'No files found to scan') !== false) {
-            $found = true;
-        }
-
-        $this->assertTrue($found);
+        $this->assertStringContainsString('No files found to scan', $this->commandTester->getDisplay());
     }
 }

--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -28,20 +28,11 @@ class DetectorTest extends TestCase
 {
     private const FIXTURES_DIR = __DIR__ . '/Fixtures/Files';
 
-    /**
-     * @var Option
-     */
-    private $option;
+    private Option $option;
 
-    /**
-     * @var Detector
-     */
-    private $detector;
+    private Detector $detector;
 
-    /**
-     * @var HintList
-     */
-    private $hintList;
+    private HintList $hintList;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
This PR:
- [x] Drops php < 7.4 support
- [x] Adds PHP 8.1 to pipeline
- [x] Updates PhpParser to 4.13 as it supports PHP 8.1

p.s. It's time to move forward