### PR TITLE
Remove --non-zero-exit-on-violation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ The ``--ignore-strings`` option will exclude strings from the code analysis, whe
 
 The ``--include-numeric-string`` option forces numeric strings such as "1234" to also be treated as a number.
 
-The ``--non-zero-exit-on-violation`` option will return a non zero exit code, when there are any magic numbers in your codebase.
-
 The ``--progress`` option will display a progress bar.
 
 The ``--strings`` option will include strings literal search in code analysis.

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -101,12 +101,6 @@ class RunCommand extends BaseCommand
                 'Suggest replacements for magic numbers'
             )
             ->addOption(
-                'non-zero-exit-on-violation',
-                null,
-                InputOption::VALUE_NONE,
-                'Return a non zero exit code when there are magic numbers'
-            )
-            ->addOption(
                 'strings',
                 null,
                 InputOption::VALUE_NONE,
@@ -208,11 +202,7 @@ class RunCommand extends BaseCommand
             $output->writeln('<info>' . $this->getResourceUsage() . '</info>');
         }
 
-        if ($detections !== [] && $input->getOption('non-zero-exit-on-violation')) {
-            return self::FAILURE;
-        }
-
-        return self::SUCCESS;
+        return $detections === [] ? self::SUCCESS : self::FAILURE;
     }
 
     private function createOption(InputInterface $input): Option

--- a/tests/Command/RunCommandTest.php
+++ b/tests/Command/RunCommandTest.php
@@ -40,7 +40,6 @@ class RunCommandTest extends TestCase
     {
         $this->commandTester->execute([
             'directories' => ['tests/Fixtures/Files'],
-            '--non-zero-exit-on-violation' => true,
         ]);
 
         $this->assertSame(RunCommand::FAILURE, $this->commandTester->getStatusCode());
@@ -51,7 +50,6 @@ class RunCommandTest extends TestCase
         $this->commandTester->execute([
             'directories' => ['tests/Fixtures/Files'],
             '--extensions' => 'assign',
-            '--non-zero-exit-on-violation' => true,
             '--hint' => true,
         ]);
 


### PR DESCRIPTION
This PR drop support of `--non-zero-exit-on-violation` option.

The argument is: phpmnd is mostly used in CI where it must fail builds in case any violation is detected so it does not make a lot of sense to use in CI and skip violations.