### PR TITLE
fix(phar): create phpmnd.phar

### DIFF
--- a/bin/createPhar
+++ b/bin/createPhar
@@ -28,7 +28,10 @@ $phar->setStub(
     "#!/usr/bin/env php
     <?php
     Phar::mapPhar('$pharName');
-    require 'phar://$pharName/bin/phpmnd';
+    require_once \"phar://$pharName/vendor/autoload.php\";
+    use Povils\PHPMND\Console\Application;
+    use Povils\PHPMND\Container;
+    (new Application(Container::create()))->run();
     __HALT_COMPILER();"
 );
 


### PR DESCRIPTION
Without correction php phpmnd.phar show :

PHP Fatal error: Cannot redeclare composerRequire4f5ba85d7e2a2f586f6e2dd0830cd962() (previously declared in phar:///home/dvp/phpmnd/phpmnd.phar/vendor/composer/autoload_real.php:73) in /home/dvp/phpmnd/vendor/composer/autoload_real.php on line 73