### PR TITLE
New Console output format (without tputs)

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -71,10 +71,7 @@ class Container
         unset($this->values[$id]);
     }
 
-    /**
-     * @return object
-     */
-    private function get(string $id)
+    private function get(string $id): object
     {
         if (!isset($this->keys[$id])) {
             throw new InvalidArgumentException(sprintf('Unknown service "%s"', $id));

--- a/src/DetectionResult.php
+++ b/src/DetectionResult.php
@@ -27,9 +27,14 @@ class DetectionResult
         $this->value = $value;
     }
 
-    public function getFile(): SplFileInfo
+    public function getSource(): string
     {
-        return $this->file;
+        return $this->file->getContents();
+    }
+
+    public function getFilePath(): string
+    {
+        return $this->file->getRealPath();
     }
 
     public function getLine(): int

--- a/src/Printer/Xml.php
+++ b/src/Printer/Xml.php
@@ -46,7 +46,7 @@ class Xml implements Printer
 
             foreach ($detectionResults as $detectionResult) {
                 $snippet = $this->getSnippet(
-                    $detectionResult->getFile()->getContents(),
+                    $detectionResult->getSource(),
                     $detectionResult->getLine(),
                     $detectionResult->getValue()
                 );
@@ -101,7 +101,7 @@ class Xml implements Printer
         $result = [];
 
         foreach ($list as $detectionResult) {
-            $result[$detectionResult->getFile()->getRelativePathname()][] = $detectionResult;
+            $result[$detectionResult->getFilePath()][] = $detectionResult;
         }
 
         return $result;

--- a/tests/DetectionResultTest.php
+++ b/tests/DetectionResultTest.php
@@ -19,7 +19,7 @@ class DetectionResultTest extends TestCase
 
         $result = new DetectionResult($file, $line, $value);
 
-        $this->assertSame($file, $result->getFile());
+        $this->assertSame($file->getRealPath(), $result->getFilePath());
         $this->assertSame($line, $result->getLine());
         $this->assertSame($value, $result->getValue());
     }

--- a/tests/Printer/XmlTest.php
+++ b/tests/Printer/XmlTest.php
@@ -38,6 +38,11 @@ XML
         $splFileInfo
             ->method('getRelativePathname')
             ->willReturn('Foo/Bar.php');
+
+        $splFileInfo
+            ->method('getRealPath')
+            ->willReturn('Foo/Bar.php');
+
         $splFileInfo
             ->method('getContents')
             ->willReturn(sprintf(


### PR DESCRIPTION
Rework Console output in order to get rid of `tputs`.

That is how it looks like:
![image](https://user-images.githubusercontent.com/1302230/177635054-88c13a51-c24f-4e85-900b-b4455c6b7925.png)


Fixes an issue https://github.com/povils/phpmnd/issues/153