### PR TITLE
Add test to verify that `Application::VERSION` match the latest git tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Run tests
         if: github.ref_type == 'branch'
         shell: bash
-        run: composer run test --exclude-group tags
+        run: vendor/bin/phpunit --exclude-group tags
 
       - name: Run release tests
         if: github.ref_type == 'tag'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,5 +72,11 @@ jobs:
         run: composer update --optimize-autoloader --no-interaction --no-progress --prefer-dist ${{ matrix.composer-flags }}
 
       - name: Run tests
+        if: github.ref_type == 'branch'
+        shell: bash
+        run: composer run test --exclude-group tags
+
+      - name: Run release tests
+        if: github.ref_type == 'tag'
         shell: bash
         run: composer run test

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends BaseApplication
 {
-    public const VERSION = '3.3.0';
+    public const VERSION = '3.4.0';
     private const NAME = 'phpmnd';
 
     private Container $container;

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Povils\PHPMND\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use Povils\PHPMND\Console\Application;
+use Povils\PHPMND\Container;
+use SebastianBergmann\Version;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+/**
+ * @author Laurent Laville
+ * @group tags
+ *   Allow to exclude this group from CI workflow when tag is not pushed
+ */
+class ApplicationTest extends TestCase
+{
+    private ApplicationTester $applicationTester;
+    protected function setUp(): void
+    {
+        $application = new Application(Container::create());
+        $application->setAutoExit(false);
+
+        $this->applicationTester = new ApplicationTester($application);
+    }
+
+    public function testApplicationVersionInstalled(): void
+    {
+        $this->applicationTester->run(['--version', '--no-ansi']);
+
+        $installedVersion = \ltrim(
+            (new Version('', dirname(__DIR__, 2)))->getVersion(),
+            '-v'
+        );
+
+        $this->assertSame(
+            \sprintf('phpmnd version %s by Povilas Susinskas', $installedVersion),
+            \trim($this->applicationTester->getDisplay())
+        );
+    }
+}


### PR DESCRIPTION
Hello,

It's almost always the case when we use an hard coded version (with `Application::VERSION`) to forget to bump it before to push a new release !

To avoid in future to avoid such case, I propose this PR that add a TestCase that is run by CI only when you'll push a tag to repository.

When you push code to a branch, PHPUnit will run this command `vendor/bin/phpunit --exclude-group tags`

```
PHPUnit 9.6.15 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.14
Configuration: /shared/backups/forks/phpmnd/phpunit.xml.dist
Random Seed:   1704792472

..........................................                        42 / 42 (100%)

Time: 00:00.231, Memory: 18.00 MB

OK (42 tests, 72 assertions)
```

But when you'll push a tag to repo, PHPUnit will run all tests including this new one (i.e) : 

```
PHPUnit 9.6.15 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.14
Configuration: /shared/backups/forks/phpmnd/phpunit.xml.dist
Random Seed:   1704792623

......................F....................                       43 / 43 (100%)

Time: 00:00.266, Memory: 20.00 MB

There was 1 failure:

1) Povils\PHPMND\Tests\Application\ApplicationTest::testApplicationVersionInstalled
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'phpmnd version g6b12352 by Povilas Susinskas'
+'phpmnd version 3.4.0 by Povilas Susinskas'

/shared/backups/forks/phpmnd/tests/Application/ApplicationTest.php:38

FAILURES!
Tests: 43, Assertions: 73, Failures: 1.
```
