### PR TITLE
Get application version from composer.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [v3.5.0]
 - Support `phpunit/php-timer` 7.0
+- Add `composer-runtime-api:"^2.0"` dependency to be able to get application version automatically
 
 ## [v3.4.1]
 - Add test to verify that `Application::VERSION` match the latest git tag

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "symfony/console": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/finder": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "composer-runtime-api": "^2.0",
         "nikic/php-parser": "^4.18 || ^5.0",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "phpunit/php-timer": "^2.0 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+        "phpunit/php-timer": "^2.0 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/console": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/finder": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
@@ -33,6 +34,9 @@
         "psr-4": {
             "Povils\\PHPMND\\Tests\\": "tests/"
         }
+    },
+    "config": {
+        "sort-packages": true
     },
     "bin": [
         "bin/phpmnd"

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Povils\PHPMND\Console;
 
+use Composer\InstalledVersions;
+use OutOfBoundsException;
 use Povils\PHPMND\Command\RunCommand;
 use Povils\PHPMND\Container;
 use Symfony\Component\Console\Application as BaseApplication;
@@ -14,14 +16,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends BaseApplication
 {
-    public const VERSION = '3.5.0';
+    public const PACKAGE_NAME = 'povils/phpmnd';
+
     private const NAME = 'phpmnd';
 
     private Container $container;
 
     public function __construct(Container $container)
     {
-        parent::__construct(self::NAME, self::VERSION);
+        parent::__construct(self::NAME, self::getPrettyVersion());
 
         $this->setDefaultCommand('run', true);
 
@@ -61,5 +64,24 @@ class Application extends BaseApplication
     protected function getDefaultCommands(): array
     {
         return [new HelpCommand(), new RunCommand()];
+    }
+
+    public static function getPrettyVersion(): string
+    {
+        // Pre 2.0 Composer runtime didn't have this class.
+        if (!class_exists(InstalledVersions::class)) {
+            return 'unknown';
+        }
+
+        try {
+            return (string) InstalledVersions::getPrettyVersion(self::PACKAGE_NAME);
+        } catch (OutOfBoundsException $e) {
+            if (preg_match('#package .*' . preg_quote(self::PACKAGE_NAME, '#') . '.* not installed#i', $e->getMessage()) === 0) {
+                throw $e;
+            }
+
+            // We have a bogus exception: how can PHPMND be not installed if we're here?
+            return 'not-installed';
+        }
     }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -31,12 +31,8 @@ class Container
     public static function create(): self
     {
         return new self([
-            Parser::class => static function (self $container): Parser {
-                return (new ParserFactory())->createForHostVersion();
-            },
-            FileParser::class => static function (self $container): FileParser {
-                return new FileParser($container->getParser());
-            },
+            Parser::class => static fn (): Parser => (new ParserFactory())->createForHostVersion(),
+            FileParser::class => static fn (self $container): FileParser => new FileParser($container->getParser()),
         ]);
     }
 
@@ -57,10 +53,7 @@ class Container
         unset($this->values[$id]);
     }
 
-    /**
-     * @return object
-     */
-    private function get(string $id)
+    private function get(string $id): object
     {
         if (!isset($this->keys[$id])) {
             throw new InvalidArgumentException(sprintf('Unknown service "%s"', $id));

--- a/src/Printer/Xml.php
+++ b/src/Printer/Xml.php
@@ -29,7 +29,7 @@ class Xml implements Printer
         $output->writeln('Generate XML output...');
         $dom = new DOMDocument();
         $rootNode = $dom->createElement('phpmnd');
-        $rootNode->setAttribute('version', Application::VERSION);
+        $rootNode->setAttribute('version', Application::getPrettyVersion());
         $rootNode->setAttribute('fileCount', (string) count($groupedList));
 
         $filesNode = $dom->createElement('files');

--- a/tests/Printer/XmlTest.php
+++ b/tests/Printer/XmlTest.php
@@ -79,7 +79,7 @@ XML
 
     private function assertXml(string $expected, string $actualFile) : void
     {
-        $expectedXml = str_replace('%%PHPMND_VERSION%%', Application::VERSION, $expected);
+        $expectedXml = str_replace('%%PHPMND_VERSION%%', Application::getPrettyVersion(), $expected);
         $this->assertXmlStringEqualsXmlString($expectedXml, file_get_contents($actualFile));
     }
 }


### PR DESCRIPTION
This PR adds `composer-runtime-api` as dependency in order to get installed version automatically.

This will help mainteners to not to forget to update application version before each release.

Alternative solution to https://github.com/povils/phpmnd/pull/175