### PR TITLE
Support phpunit/php-timer 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "composer-runtime-api": "^2.0",
         "nikic/php-parser": "^4.18 || ^5.0",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "phpunit/php-timer": "^2.0 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "phpunit/php-timer": "^2.0 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/console": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },


### PR DESCRIPTION
This PR adds supprot for phpunit/php-timer 8 which was release a day ago.