### PR TITLE
Use addCommands method to simplify RunCommandTest

### DIFF
--- a/tests/Command/RunCommandTest.php
+++ b/tests/Command/RunCommandTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Povils\PHPMND\Tests\Command;
 
-use Composer\InstalledVersions;
 use PHPUnit\Framework\TestCase;
 use Povils\PHPMND\Command\RunCommand;
 use Povils\PHPMND\Console\Application;
@@ -20,11 +19,7 @@ class RunCommandTest extends TestCase
         $application = new Application(Container::create());
         $command = new RunCommand();
 
-        if (version_compare((string)InstalledVersions::getPrettyVersion('symfony/console'), 'v7.4', '<')) {
-            $application->add($command);
-        } else {
-            $application->addCommand($command);
-        }
+        $application->addCommands([$command]);
 
         $this->commandTester = new CommandTester($application->find($command->getName()));
     }


### PR DESCRIPTION
This PR utilize `addCommands` method to simplify RunCommandTest.

Thanks @llaville to point it out in the https://github.com/povils/phpmnd/pull/191#discussion_r2837081300